### PR TITLE
Adding reqs for widget building

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ m2r
 ipykernel
 ipywidgets
 nbsphinx
+jupyter_sphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'm2r',
     'nbsphinx',
+    'jupyter_sphinx.embed_widgets',
 ]
 
 exclude_patterns = ['_build', '**.ipynb_checkpoints']


### PR DESCRIPTION
When saving notebooks by using the 'Save Notebook Widget State' dropdown, the sliders and others are embedded into the resulting html page through sphinx.