### PR TITLE
Include license in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include sk_dsp_comm/ca1thru37.txt
 include logo.png
 include Capture_Buffer.png
 include two_channel_stream.png
+include LICENSE.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE.md


### PR DESCRIPTION
The BSD 2-clause license requires the license to be included in all copies of the code.