### PR TITLE
Pep 8 updates

### DIFF
--- a/docs/source/nb_examples/Block_Codes.ipynb
+++ b/docs/source/nb_examples/Block_Codes.ipynb
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cc1 = block.fec_cyclic('1011')"
+    "cc1 = block.FECCyclic('1011')"
    ]
   },
   {
@@ -234,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cc1 = block.fec_cyclic('101001')\n",
+    "cc1 = block.FECCyclic('101001')\n",
     "N_blocks_per_frame = 2000\n",
     "N_bits_per_frame = N_blocks_per_frame*cc1.k\n",
     "EbN0 = 6\n",
@@ -246,7 +246,7 @@
     "    x = randint(0,2,N_bits_per_frame)\n",
     "    y = cc1.cyclic_encoder(x)\n",
     "    # Add channel noise to bits and scale to +/- 1\n",
-    "    yn = dc.cpx_AWGN(2*y-1,EbN0-10*log10(cc1.n/cc1.k),1) # Channel SNR is dB less\n",
+    "    yn = dc.cpx_awgn(2*y-1,EbN0-10*log10(cc1.n/cc1.k),1) # Channel SNR is dB less\n",
     "    # Scale back to 0 and 1\n",
     "    yn = ((sign(yn.real)+1)/2).astype(int)\n",
     "    z = cc1.cyclic_decoder(yn)\n",
@@ -473,7 +473,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hh1 = block.fec_hamming(3)"
+    "hh1 = block.FECHamming(3)"
    ]
   },
   {
@@ -508,7 +508,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hh1 = block.fec_hamming(5)\n",
+    "hh1 = block.FECHamming(5)\n",
     "N_blocks_per_frame = 20000\n",
     "N_bits_per_frame = N_blocks_per_frame*hh1.k\n",
     "EbN0 = 8\n",
@@ -521,7 +521,7 @@
     "    x = randint(0,2,N_bits_per_frame)\n",
     "    y = hh1.hamm_encoder(x)\n",
     "    # Add channel noise to bits and scale to +/- 1\n",
-    "    yn = dc.cpx_AWGN(2*y-1,EbN0-10*log10(hh1.n/hh1.k),1) # Channel SNR is dB less\n",
+    "    yn = dc.cpx_awgn(2*y-1,EbN0-10*log10(hh1.n/hh1.k),1) # Channel SNR is dB less\n",
     "    # Scale back to 0 and 1\n",
     "    yn = ((sign(yn.real)+1)/2).astype(int)\n",
     "    z = hh1.hamm_decoder(yn)\n",

--- a/docs/source/nb_examples/Continuous-Time Signals and Systems using sigsys.ipynb
+++ b/docs/source/nb_examples/Continuous-Time Signals and Systems using sigsys.ipynb
@@ -1113,7 +1113,7 @@
    "outputs": [],
    "source": [
     "import sk_dsp_comm.digitalcom as dc\n",
-    "y_PN5_bits = ss.PN_gen(10000,5)\n",
+    "y_PN5_bits = ss.pn_gen(10000,5)\n",
     "# Convert to waveform level shifted to +/-1 amplitude\n",
     "y = 2*signal.lfilter(ones(10),1,ss.upsample(y_PN5_bits,10))-1\n",
     "# Find the time averaged autocorrelation function normalized\n",
@@ -1354,7 +1354,7 @@
    "outputs": [],
    "source": [
     "import sk_dsp_comm.digitalcom as dc\n",
-    "x_PN4_bits = ss.PN_gen(10000,6)\n",
+    "x_PN4_bits = ss.pn_gen(10000,6)\n",
     "# Convert to waveform level shifted to +/-1 amplitude\n",
     "x_s = 2*signal.lfilter(ones(10),1,ss.upsample(x_PN4_bits,10))-1\n",
     "# Form a delayed version of x_S\n",

--- a/docs/source/nb_examples/Convolutional_Codes.ipynb
+++ b/docs/source/nb_examples/Convolutional_Codes.ipynb
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A convolutional encoder object can be created with the `fec.fec_conv` method. The rate of the object will be determined by the number of generator polynomials used. Right now, only rate 1/2 and rate 1/3 are supported, so 2 or three generator polynomials can be used. The following table shows ideal rate 1/2 generator polynomials. These are also included in the docstring. "
+    "A convolutional encoder object can be created with the `fec.FECConv` method. The rate of the object will be determined by the number of generator polynomials used. Right now, only rate 1/2 and rate 1/3 are supported, so 2 or three generator polynomials can be used. The following table shows ideal rate 1/2 generator polynomials. These are also included in the docstring. "
    ]
   },
   {
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cc1 = fec.fec_conv(('111','101'),10)"
+    "cc1 = fec.FECConv(('111','101'),10)"
    ]
   },
   {
@@ -190,7 +190,7 @@
     "EbN0 = 4\n",
     "total_bit_errors = 0\n",
     "total_bit_count = 0\n",
-    "cc1 = fec.fec_conv(('11101','10011'),25)\n",
+    "cc1 = fec.FECConv(('11101','10011'),25)\n",
     "# Encode with shift register starting state of '0000'\n",
     "state = '0000'\n",
     "while total_bit_errors < 100:\n",
@@ -198,7 +198,7 @@
     "    x = randint(0,2,N_bits_per_frame)\n",
     "    y,state = cc1.conv_encoder(x,state)\n",
     "    # Add channel noise to bits, include antipodal level shift to [-1,1]\n",
-    "    yn_soft = dc.cpx_AWGN(2*y-1,EbN0-3,1) # Channel SNR is 3 dB less for rate 1/2\n",
+    "    yn_soft = dc.cpx_awgn(2*y-1,EbN0-3,1) # Channel SNR is 3 dB less for rate 1/2\n",
     "    yn_hard = ((sign(yn_soft.real)+1)/2).astype(int)\n",
     "    z = cc1.viterbi_decoder(yn_hard,'hard')\n",
     "    # Count bit errors\n",
@@ -303,7 +303,7 @@
     "EbN0 = 2\n",
     "total_bit_errors = 0\n",
     "total_bit_count = 0\n",
-    "cc1 = fec.fec_conv(('11101','10011'),25)\n",
+    "cc1 = fec.FECConv(('11101','10011'),25)\n",
     "# Encode with shift register starting state of '0000'\n",
     "state = '0000'\n",
     "while total_bit_errors < 100:\n",
@@ -311,7 +311,7 @@
     "    x = randint(0,2,N_bits_per_frame)\n",
     "    y,state = cc1.conv_encoder(x,state)\n",
     "    # Add channel noise to bits, include antipodal level shift to [-1,1]\n",
-    "    yn = dc.cpx_AWGN(2*y-1,EbN0-3,1) # Channel SNR is 3dB less for rate 1/2\n",
+    "    yn = dc.cpx_awgn(2*y-1,EbN0-3,1) # Channel SNR is 3dB less for rate 1/2\n",
     "    # Scale & level shift to three-bit quantization levels [0,7]\n",
     "    yn = (yn.real+1)/2*7\n",
     "    z = cc1.viterbi_decoder(yn.real,'soft',quant_level=3)\n",
@@ -410,7 +410,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cc2 = fec.fec_conv(('111','111','101'),10)\n",
+    "cc2 = fec.FECConv(('111','111','101'),10)\n",
     "cc2.trellis_plot()"
    ]
   },
@@ -481,7 +481,7 @@
     "EbN0 = 3\n",
     "total_bit_errors = 0\n",
     "total_bit_count = 0\n",
-    "cc1 = fec.fec_conv(('11111','11011','10101'),25)\n",
+    "cc1 = fec.FECConv(('11111','11011','10101'),25)\n",
     "# Encode with shift register starting state of '0000'\n",
     "state = '0000'\n",
     "while total_bit_errors < 100:\n",
@@ -489,7 +489,7 @@
     "    x = randint(0,2,N_bits_per_frame)\n",
     "    y,state = cc1.conv_encoder(x,state)\n",
     "    # Add channel noise to bits, include antipodal level shift to [-1,1]\n",
-    "    yn_soft = dc.cpx_AWGN(2*y-1,EbN0-10*log10(3),1) # Channel SNR is 10*log10(3) dB less\n",
+    "    yn_soft = dc.cpx_awgn(2*y-1,EbN0-10*log10(3),1) # Channel SNR is 10*log10(3) dB less\n",
     "    yn_hard = ((sign(yn_soft.real)+1)/2).astype(int)\n",
     "    z = cc1.viterbi_decoder(yn_hard.real,'hard')\n",
     "    # Count bit errors\n",
@@ -560,7 +560,7 @@
     "EbN0 = 2\n",
     "total_bit_errors = 0\n",
     "total_bit_count = 0\n",
-    "cc1 = fec.fec_conv(('11111','11011','10101'),25)\n",
+    "cc1 = fec.FECConv(('11111','11011','10101'),25)\n",
     "# Encode with shift register starting state of '0000'\n",
     "state = '0000'\n",
     "while total_bit_errors < 100:\n",
@@ -568,7 +568,7 @@
     "    x = randint(0,2,N_bits_per_frame)\n",
     "    y,state = cc1.conv_encoder(x,state)\n",
     "    # Add channel noise to bits, include antipodal level shift to [-1,1] \n",
-    "    yn = dc.cpx_AWGN(2*y-1,EbN0-10*log10(3),1) # Channel SNR is 10*log10(3) dB less\n",
+    "    yn = dc.cpx_awgn(2*y-1,EbN0-10*log10(3),1) # Channel SNR is 10*log10(3) dB less\n",
     "    # Translate to [0,7]\n",
     "    yn = (yn.real+1)/2*7\n",
     "    z = cc1.viterbi_decoder(yn,'soft',quant_level=3)\n",

--- a/sk_dsp_comm/coeff2header.py
+++ b/sk_dsp_comm/coeff2header.py
@@ -182,6 +182,8 @@ def freqz_resp_list(b, a=np.array([1]), mode='dB', fs=1.0, n_pts=1024, fsize=(6,
     if type(b) == list:
         # We have a list of filters
         N_filt = len(b)
+    else:
+        return None
     f = np.arange(0, n_pts) / (2.0 * n_pts)
     for n in range(N_filt):
         w, H = signal.freqz(b[n], a[n], 2 * np.pi * f)

--- a/sk_dsp_comm/coeff2header.py
+++ b/sk_dsp_comm/coeff2header.py
@@ -39,10 +39,10 @@ from logging import getLogger
 log = getLogger(__name__)
 
 
-def FIR_header(fname_out, h):
+def fir_header(fname_out, h):
     """
-    Write FIR Filter Header Files 
-    
+    Write FIR Filter Header Files
+
     Mark Wickert February 2015
     """
     M = len(h)
@@ -74,7 +74,7 @@ def FIR_header(fname_out, h):
     f.close()
 
 
-def FIR_fix_header(fname_out, h):
+def fir_fix_header(fname_out, h):
     """
     Write FIR Fixed-Point Filter Header Files 
     
@@ -110,7 +110,7 @@ def FIR_fix_header(fname_out, h):
     f.close()
 
 
-def IIR_sos_header(fname_out, SOS_mat):
+def iir_sos_header(fname_out, SOS_mat):
     """
     Write IIR SOS Header Files
     File format is compatible with CMSIS-DSP IIR 
@@ -155,7 +155,7 @@ def IIR_sos_header(fname_out, SOS_mat):
     f.close()
 
 
-def freqz_resp_list(b, a=np.array([1]), mode='dB', fs=1.0, Npts=1024, fsize=(6, 4)):
+def freqz_resp_list(b, a=np.array([1]), mode='dB', fs=1.0, n_pts=1024, fsize=(6, 4)):
     """
     A method for displaying digital filter frequency response magnitude,
     phase, and group delay. A plot is produced using matplotlib
@@ -174,7 +174,7 @@ def freqz_resp_list(b, a=np.array([1]), mode='dB', fs=1.0, Npts=1024, fsize=(6, 
     mode : display mode: 'dB' magnitude, 'phase' in radians, or
             'groupdelay_s' in samples and 'groupdelay_t' in sec, 
             all versus frequency in Hz
-    Npts : number of points to plot; default is 1024
+    n_pts : number of points to plot; default is 1024
     fsize : figure size; defult is (6,4) inches
 
     Mark Wickert, January 2015
@@ -182,7 +182,7 @@ def freqz_resp_list(b, a=np.array([1]), mode='dB', fs=1.0, Npts=1024, fsize=(6, 
     if type(b) == list:
         # We have a list of filters
         N_filt = len(b)
-    f = np.arange(0, Npts) / (2.0 * Npts)
+    f = np.arange(0, n_pts) / (2.0 * n_pts)
     for n in range(N_filt):
         w, H = signal.freqz(b[n], a[n], 2 * np.pi * f)
         if n == 0:
@@ -245,7 +245,7 @@ def freqz_resp_list(b, a=np.array([1]), mode='dB', fs=1.0, Npts=1024, fsize=(6, 
             log.info(s1 + s2)
 
 
-def CA_code_header(fname_out, Nca):
+def ca_code_header(fname_out, Nca):
     """
     Write 1023 bit CA (Gold) Code Header Files
 

--- a/sk_dsp_comm/digitalcom.py
+++ b/sk_dsp_comm/digitalcom.py
@@ -44,7 +44,7 @@ from .sigsys import nrz_bits2
 from .sigsys import pn_gen
 from .sigsys import m_seq
 from .sigsys import cpx_awgn
-from .sigsys import CIC
+from .sigsys import cic
 
 from logging import getLogger
 log = getLogger(__name__)

--- a/sk_dsp_comm/digitalcom.py
+++ b/sk_dsp_comm/digitalcom.py
@@ -101,7 +101,7 @@ def farrow_resample(x, fs_old, fs_new):
     >>> Tsin = 1 / fsin
     >>> N = 200
     >>> ts = 1
-    >>> x, b, data = dc.MPSK_bb(N+12, Ns, 4, 'rc')
+    >>> x, b, data = dc.mpsk_bb(N+12, Ns, 4, 'rc')
     >>> x = x[12*Ns:]
     >>> xxI = x.real
     >>> M = 15
@@ -323,7 +323,7 @@ def bit_errors(tx_data, rx_data, n_corr=1024, n_transient=0):
     return Bit_count,np.sum(Bit_errors)
 
 
-def QAM_bb(n_symb, ns, mod_type='16qam', pulse='rect', alpha=0.35):
+def qam_bb(n_symb, ns, mod='16qam', pulse='rect', alpha=0.35):
     """
     QAM_BB_TX: A complex baseband transmitter 
     x,b,tx_data = QAM_bb(K,Ns,M)
@@ -359,13 +359,13 @@ def QAM_bb(n_symb, ns, mod_type='16qam', pulse='rect', alpha=0.35):
     else:
         raise ValueError('pulse shape must be src, rc, or rect')
         
-    if mod_type.lower() == 'qpsk':
+    if mod.lower() == 'qpsk':
         M = 2 # bits per symbol
-    elif mod_type.lower() == '16qam':
+    elif mod.lower() == '16qam':
         M = 4
-    elif mod_type.lower() == '64qam':
+    elif mod.lower() == '64qam':
         M = 8
-    elif mod_type.lower() == '256qam':
+    elif mod.lower() == '256qam':
         M = 16
     else:
         raise ValueError('Unknown mod_type')
@@ -398,7 +398,7 @@ def QAM_bb(n_symb, ns, mod_type='16qam', pulse='rect', alpha=0.35):
     return x, b, xI+1j*xQ
 
 
-def QAM_SEP(tx_data,rx_data,mod_type,Ncorr = 1024,Ntransient = 0,SEP_disp=True):
+def qam_sep(tx_data, rx_data, mod, n_corr=1024, n_transient=0, SEP_disp=True):
     """
     Nsymb, Nerr, SEP_hat =
     QAM_symb_errors(tx_data,rx_data,mod_type,Ncorr = 1024,Ntransient = 0)
@@ -411,20 +411,20 @@ def QAM_SEP(tx_data,rx_data,mod_type,Ncorr = 1024,Ntransient = 0,SEP_disp=True):
     Note: Ncorr needs to be even
     """
     #Remove Ntransient symbols and makes lengths equal
-    tx_data = tx_data[Ntransient:]
-    rx_data = rx_data[Ntransient:]
+    tx_data = tx_data[n_transient:]
+    rx_data = rx_data[n_transient:]
     Nmin = min([len(tx_data),len(rx_data)])
     tx_data = tx_data[:Nmin]
     rx_data = rx_data[:Nmin]
     
     # Perform level translation and quantize the soft symbol values
-    if mod_type.lower() == 'qpsk':
+    if mod.lower() == 'qpsk':
         M = 2 # bits per symbol
-    elif mod_type.lower() == '16qam':
+    elif mod.lower() == '16qam':
         M = 4
-    elif mod_type.lower() == '64qam':
+    elif mod.lower() == '64qam':
         M = 8
-    elif mod_type.lower() == '256qam':
+    elif mod.lower() == '256qam':
         M = 16
     else:
         raise ValueError('Unknown mod_type')
@@ -441,10 +441,10 @@ def QAM_SEP(tx_data,rx_data,mod_type,Ncorr = 1024,Ntransient = 0,SEP_disp=True):
     rx_data.imag[s2i] = np.zeros(len(s2i))
     rx_data = 2*rx_data - (M - 1)*(1 + 1j)
     #Correlate the first Ncorr symbols at four possible phase rotations
-    R0,lags = xcorr(rx_data,tx_data,Ncorr)
-    R1,lags = xcorr(rx_data*(1j)**1,tx_data,Ncorr) 
-    R2,lags = xcorr(rx_data*(1j)**2,tx_data,Ncorr) 
-    R3,lags = xcorr(rx_data*(1j)**3,tx_data,Ncorr) 
+    R0,lags = xcorr(rx_data, tx_data, n_corr)
+    R1,lags = xcorr(rx_data * (1j) ** 1, tx_data, n_corr)
+    R2,lags = xcorr(rx_data * (1j) ** 2, tx_data, n_corr)
+    R3,lags = xcorr(rx_data * (1j) ** 3, tx_data, n_corr)
     #Place the zero lag value in the center of the array
     R0max = np.max(R0.real)
     R1max = np.max(R1.real)
@@ -488,46 +488,46 @@ def QAM_SEP(tx_data,rx_data,mod_type,Ncorr = 1024,Ntransient = 0,SEP_disp=True):
     return  len(errors), len(idx), len(idx)/float(len(errors))
 
 
-def GMSK_bb(N_bits, Ns, MSK = 0,BT = 0.35):
+def gmsk_bb(n_bits, ns, msk=0, bt=0.35):
     """
     MSK/GMSK Complex Baseband Modulation
     x,data = gmsk(N_bits, Ns, BT = 0.35, MSK = 0)
 
     Parameters
     ----------
-    N_bits : number of symbols processed
-    Ns : the number of samples per bit
-    MSK : 0 for no shaping which is standard MSK, MSK <> 0 --> GMSK is generated.
-    BT : premodulation Bb*T product which sets the bandwidth of the Gaussian lowpass filter
+    n_bits : number of symbols processed
+    ns : the number of samples per bit
+    msk : 0 for no shaping which is standard MSK, MSK <> 0 --> GMSK is generated.
+    bt : premodulation Bb*T product which sets the bandwidth of the Gaussian lowpass filter
 
     Mark Wickert Python version November 2014
     """
-    x, b, data = nrz_bits(N_bits, Ns)
+    x, b, data = nrz_bits(n_bits, ns)
     # pulse length 2*M*Ns
     M = 4
-    n = np.arange(-M*Ns,M*Ns+1)
-    p = np.exp(-2*np.pi**2*BT**2/np.log(2)*(n/float(Ns))**2);
+    n = np.arange(-M * ns, M * ns + 1)
+    p = np.exp(-2 * np.pi ** 2 * bt ** 2 / np.log(2) * (n / float(ns)) ** 2);
     p = p/np.sum(p);
 
     # Gaussian pulse shape if MSK not zero
-    if MSK != 0:
+    if msk != 0:
         x = signal.lfilter(p,1,x)
-    y = np.exp(1j*np.pi/2*np.cumsum(x)/Ns)
+    y = np.exp(1j * np.pi / 2 * np.cumsum(x) / ns)
     return y, data
 
 
-def MPSK_bb(N_symb,Ns,M,pulse='rect',alpha = 0.25,MM=6):
+def mpsk_bb(n_symb, ns, mod, pulse='rect', alpha=0.25, m=6):
     """
     Generate a complex baseband MPSK signal with pulse shaping.
 
     Parameters
     ----------
-    N_symb : number of MPSK symbols to produce
-    Ns : the number of samples per bit,
-    M : MPSK modulation order, e.g., 4, 8, 16, ...
-    pulse_type : 'rect' , 'rc', 'src' (default 'rect')
+    n_symb : number of MPSK symbols to produce
+    ns : the number of samples per bit,
+    mod : MPSK modulation order, e.g., 4, 8, 16, ...
+    pulse : 'rect' , 'rc', 'src' (default 'rect')
     alpha : excess bandwidth factor(default 0.25)
-    MM : single sided pulse duration (default = 6) 
+    m : single sided pulse duration (default = 6) 
 
     Returns
     -------
@@ -546,7 +546,7 @@ def MPSK_bb(N_symb,Ns,M,pulse='rect',alpha = 0.25,MM=6):
     >>> from sk_dsp_comm import digitalcom as dc
     >>> import scipy.signal as signal
     >>> import matplotlib.pyplot as plt
-    >>> x,b,data = dc.MPSK_bb(500,10,8,'src',0.35)
+    >>> x,b,data = dc.mpsk_bb(500,10,8,'src',0.35)
     >>> # Matched filter received signal x
     >>> y = signal.lfilter(b,1,x)
     >>> plt.plot(y.real[12*10:],y.imag[12*10:])
@@ -557,76 +557,76 @@ def MPSK_bb(N_symb,Ns,M,pulse='rect',alpha = 0.25,MM=6):
     >>> plt.plot(y.real[12*10::10],y.imag[12*10::10],'r.')
     >>> plt.show()
     """
-    data = np.random.randint(0,M,N_symb) 
-    xs = np.exp(1j*2*np.pi/M*data)
-    x = np.hstack((xs.reshape(N_symb,1),np.zeros((N_symb,int(Ns)-1))))
+    data = np.random.randint(0, mod, n_symb)
+    xs = np.exp(1j * 2 * np.pi / mod * data)
+    x = np.hstack((xs.reshape(n_symb, 1), np.zeros((n_symb, int(ns) - 1))))
     x =x.flatten()
     if pulse.lower() == 'rect':
-        b = np.ones(int(Ns))
+        b = np.ones(int(ns))
     elif pulse.lower() == 'rc':
-        b = rc_imp(Ns,alpha,MM)
+        b = rc_imp(ns, alpha, m)
     elif pulse.lower() == 'src':
-        b = sqrt_rc_imp(Ns,alpha,MM)
+        b = sqrt_rc_imp(ns, alpha, m)
     else:
         raise ValueError('pulse type must be rec, rc, or src')
     x = signal.lfilter(b,1,x)
-    if M == 4:
+    if mod == 4:
         x = x*np.exp(1j*np.pi/4); # For QPSK points in quadrants
-    return x,b/float(Ns),data
+    return x, b / float(ns), data
 
 
-def QPSK_rx(fc,N_symb,Rs,EsN0=100,fs=125,lfsr_len=10,phase=0,pulse='src'):
+def qpsk_rx(fc, n_symb, rs, es_n0=100, fs=125, lfsr_len=10, phase=0, pulse='src'):
     """
     This function generates
     """
-    Ns = int(np.round(fs/Rs))
+    Ns = int(np.round(fs / rs))
     log.info('Ns = ', Ns)
     log.info('Rs = ', fs/float(Ns))
-    log.info('EsN0 = ', EsN0, 'dB')
+    log.info('EsN0 = ', es_n0, 'dB')
     log.info('phase = ', phase, 'degrees')
     log.info('pulse = ', pulse)
-    x, b, data = QPSK_bb(N_symb,Ns,lfsr_len,pulse)
+    x, b, data = qpsk_bb(n_symb, Ns, lfsr_len, pulse)
     # Add AWGN to x
-    x = cpx_awgn(x, EsN0, Ns)
+    x = cpx_awgn(x, es_n0, Ns)
     n = np.arange(len(x))
     xc = x*np.exp(1j*2*np.pi*fc/float(fs)*n) * np.exp(1j*phase)
     return xc, b, data
 
 
-def QPSK_tx(fc,N_symb,Rs,fs=125,lfsr_len=10,pulse='src'):
+def qpsk_tx(fc, n_symb, rs, fs=125, lfsr_len=10, pulse='src'):
     """
 
     """
-    Ns = int(np.round(fs/Rs))
+    Ns = int(np.round(fs / rs))
     log.info('Ns = ', Ns)
     log.info('Rs = ', fs/float(Ns))
     log.info('pulse = ', pulse)
-    x, b, data = QPSK_bb(N_symb,Ns,lfsr_len,pulse)
+    x, b, data = qpsk_bb(n_symb, Ns, lfsr_len, pulse)
     n = np.arange(len(x))
     xc = x*np.exp(1j*2*np.pi*fc/float(fs)*n)
     return xc, b, data 
 
 
-def QPSK_bb(N_symb,Ns,lfsr_len=5,pulse='src',alpha=0.25,M=6):
+def qpsk_bb(n_symb, ns, lfsr_len=5, pulse='src', alpha=0.25, m=6):
     """
     
     """
     if lfsr_len > 0:  # LFSR data
-        data = pn_gen(2 * N_symb, lfsr_len)
+        data = pn_gen(2 * n_symb, lfsr_len)
         dataI = data[0::2]
         dataQ = data[1::2]
-        xI, b = nrz_bits2(dataI, Ns, pulse, alpha, M)
-        xQ, b = nrz_bits2(dataQ, Ns, pulse, alpha, M)
+        xI, b = nrz_bits2(dataI, ns, pulse, alpha, m)
+        xQ, b = nrz_bits2(dataQ, ns, pulse, alpha, m)
     else:             # Random data
-        data = np.zeros(2*N_symb)
-        xI, b, data[0::2] = nrz_bits(N_symb, Ns, pulse, alpha, M)
-        xQ, b, data[1::2] = nrz_bits(N_symb, Ns, pulse, alpha, M)
+        data = np.zeros(2 * n_symb)
+        xI, b, data[0::2] = nrz_bits(n_symb, ns, pulse, alpha, m)
+        xQ, b, data[1::2] = nrz_bits(n_symb, ns, pulse, alpha, m)
     #print('P_I: ',np.var(xI), 'P_Q: ',np.var(xQ))
     x = (xI + 1j*xQ)/np.sqrt(2.)
     return x, b, data
 
 
-def QPSK_BEP(tx_data,rx_data,Ncorr = 1024,Ntransient = 0):
+def qpsk_bep(tx_data, rx_data, n_corr = 1024, n_transient = 0):
     """
     Count bit errors between a transmitted and received QPSK signal.
     Time delay between streams is detected as well as ambiquity resolution
@@ -637,17 +637,17 @@ def QPSK_BEP(tx_data,rx_data,Ncorr = 1024,Ntransient = 0):
     """
     
     #Remove Ntransient symbols
-    tx_data = tx_data[Ntransient:]
-    rx_data = rx_data[Ntransient:]
+    tx_data = tx_data[n_transient:]
+    rx_data = rx_data[n_transient:]
     #Correlate the first Ncorr symbols at four possible phase rotations
-    R0 = np.fft.ifft(np.fft.fft(rx_data,Ncorr)*
-                     np.conj(np.fft.fft(tx_data,Ncorr)))
-    R1 = np.fft.ifft(np.fft.fft(1j*rx_data,Ncorr)*
-                     np.conj(np.fft.fft(tx_data,Ncorr)))
-    R2 = np.fft.ifft(np.fft.fft(-1*rx_data,Ncorr)*
-                     np.conj(np.fft.fft(tx_data,Ncorr)))
-    R3 = np.fft.ifft(np.fft.fft(-1j*rx_data,Ncorr)*
-                     np.conj(np.fft.fft(tx_data,Ncorr)))
+    R0 = np.fft.ifft(np.fft.fft(rx_data, n_corr) *
+                     np.conj(np.fft.fft(tx_data, n_corr)))
+    R1 = np.fft.ifft(np.fft.fft(1j * rx_data, n_corr) *
+                     np.conj(np.fft.fft(tx_data, n_corr)))
+    R2 = np.fft.ifft(np.fft.fft(-1 * rx_data, n_corr) *
+                     np.conj(np.fft.fft(tx_data, n_corr)))
+    R3 = np.fft.ifft(np.fft.fft(-1j * rx_data, n_corr) *
+                     np.conj(np.fft.fft(tx_data, n_corr)))
     #Place the zero lag value in the center of the array
     R0 = np.fft.fftshift(R0)
     R1 = np.fft.fftshift(R1)
@@ -663,13 +663,13 @@ def QPSK_BEP(tx_data,rx_data,Ncorr = 1024,Ntransient = 0):
     kmax = kphase_max[0]
     #Correlation lag value is zero at the center of the array
     if kmax == 0:
-        lagmax = np.where(R0.real == Rmax)[0] - Ncorr/2
+        lagmax = np.where(R0.real == Rmax)[0] - n_corr / 2
     elif kmax == 1:
-        lagmax = np.where(R1.real == Rmax)[0] - Ncorr/2
+        lagmax = np.where(R1.real == Rmax)[0] - n_corr / 2
     elif kmax == 2: 
-        lagmax = np.where(R2.real == Rmax)[0] - Ncorr/2
+        lagmax = np.where(R2.real == Rmax)[0] - n_corr / 2
     elif kmax == 3:
-        lagmax = np.where(R3.real == Rmax)[0] - Ncorr/2
+        lagmax = np.where(R3.real == Rmax)[0] - n_corr / 2
     taumax = lagmax[0]
     log.info('kmax =  %d, taumax = %d' % (kmax, taumax))
     # Count bit and symbol errors over the entire input ndarrays
@@ -696,7 +696,7 @@ def QPSK_BEP(tx_data,rx_data,Ncorr = 1024,Ntransient = 0):
     return S_count,np.sum(I_errors),np.sum(Q_errors),np.sum(S_errors)
 
 
-def BPSK_BEP(tx_data,rx_data,Ncorr = 1024,Ntransient = 0):
+def bpsk_bep(tx_data, rx_data, n_corr=1024, n_transient=0):
     """
     Count bit errors between a transmitted and received BPSK signal.
     Time delay between streams is detected as well as ambiquity resolution
@@ -707,13 +707,13 @@ def BPSK_BEP(tx_data,rx_data,Ncorr = 1024,Ntransient = 0):
     """
     
     #Remove Ntransient symbols
-    tx_data = tx_data[Ntransient:]
-    rx_data = rx_data[Ntransient:]
+    tx_data = tx_data[n_transient:]
+    rx_data = rx_data[n_transient:]
     #Correlate the first Ncorr symbols at four possible phase rotations
-    R0 = np.fft.ifft(np.fft.fft(rx_data,Ncorr)*
-                     np.conj(np.fft.fft(tx_data,Ncorr)))
-    R1 = np.fft.ifft(np.fft.fft(-1*rx_data,Ncorr)*
-                     np.conj(np.fft.fft(tx_data,Ncorr)))
+    R0 = np.fft.ifft(np.fft.fft(rx_data, n_corr) *
+                     np.conj(np.fft.fft(tx_data, n_corr)))
+    R1 = np.fft.ifft(np.fft.fft(-1 * rx_data, n_corr) *
+                     np.conj(np.fft.fft(tx_data, n_corr)))
     #Place the zero lag value in the center of the array
     R0 = np.fft.fftshift(R0)
     R1 = np.fft.fftshift(R1)
@@ -725,9 +725,9 @@ def BPSK_BEP(tx_data,rx_data,Ncorr = 1024,Ntransient = 0):
     kmax = kphase_max[0]
     #Correlation lag value is zero at the center of the array
     if kmax == 0:
-        lagmax = np.where(R0.real == Rmax)[0] - Ncorr/2
+        lagmax = np.where(R0.real == Rmax)[0] - n_corr / 2
     elif kmax == 1:
-        lagmax = np.where(R1.real == Rmax)[0] - Ncorr/2
+        lagmax = np.where(R1.real == Rmax)[0] - n_corr / 2
     taumax = int(lagmax[0])
     log.info('kmax =  %d, taumax = %d' % (kmax, taumax))
     #return R0,R1,R2,R3
@@ -752,7 +752,7 @@ def BPSK_BEP(tx_data,rx_data,Ncorr = 1024,Ntransient = 0):
     return S_count,np.sum(S_errors)
 
 
-def BPSK_tx(N_bits,Ns,ach_fc=2.0,ach_lvl_dB=-100,pulse='rect',alpha = 0.25,M=6):
+def bpsk_tx(n_bits, ns, ach_fc=2.0, ach_lvl_dB=-100, pulse='rect', alpha = 0.25, m=6):
     """
     Generates biphase shift keyed (BPSK) transmitter with adjacent channel interference.
 
@@ -764,13 +764,13 @@ def BPSK_tx(N_bits,Ns,ach_fc=2.0,ach_lvl_dB=-100,pulse='rect',alpha = 0.25,M=6):
 
     Parameters
     ----------
-    N_bits : the number of bits to simulate
-    Ns : the number of samples per bit
+    n_bits : the number of bits to simulate
+    ns : the number of samples per bit
     ach_fc : the frequency offset of the adjacent channel signals (default 2.0)
     ach_lvl_dB : the level of the adjacent channel signals in dB (default -100)
     pulse : the pulse shape 'rect' or 'src'
     alpha : square root raised cosine pulse shape factor (default = 0.25)
-    M : square root raised cosine pulse truncation factor (default = 6)
+    m : square root raised cosine pulse truncation factor (default = 6)
 
     Returns
     -------
@@ -783,19 +783,19 @@ def BPSK_tx(N_bits,Ns,ach_fc=2.0,ach_lvl_dB=-100,pulse='rect',alpha = 0.25,M=6):
 
     Examples
     --------
-    >>> x,b,data0 = BPSK_tx(1000,10,'src')
+    >>> x,b,data0 = bpsk_tx(1000,10,'src')
     """
-    x0,b,data0 = nrz_bits(N_bits, Ns, pulse, alpha, M)
-    x1p,b,data1p = nrz_bits(N_bits, Ns, pulse, alpha, M)
-    x1m,b,data1m = nrz_bits(N_bits, Ns, pulse, alpha, M)
+    x0,b,data0 = nrz_bits(n_bits, ns, pulse, alpha, m)
+    x1p,b,data1p = nrz_bits(n_bits, ns, pulse, alpha, m)
+    x1m,b,data1m = nrz_bits(n_bits, ns, pulse, alpha, m)
     n = np.arange(len(x0))
-    x1p = x1p*np.exp(1j*2*np.pi*ach_fc/float(Ns)*n)
-    x1m = x1m*np.exp(-1j*2*np.pi*ach_fc/float(Ns)*n)
+    x1p = x1p*np.exp(1j * 2 * np.pi * ach_fc / float(ns) * n)
+    x1m = x1m*np.exp(-1j * 2 * np.pi * ach_fc / float(ns) * n)
     ach_lvl = 10**(ach_lvl_dB/20.)
     return x0 + ach_lvl*(x1p + x1m), b, data0
 
 
-def rc_imp(Ns,alpha,M=6):
+def rc_imp(ns, alpha, m=6):
     """
     A truncated raised cosine pulse used in digital communications.
 
@@ -804,9 +804,9 @@ def rc_imp(Ns,alpha,M=6):
 
     Parameters
     ----------
-    Ns : number of samples per symbol
+    ns : number of samples per symbol
     alpha : excess bandwidth factor on (0, 1), e.g., 0.35
-    M : equals RC one-sided symbol truncation factor
+    m : equals RC one-sided symbol truncation factor
 
     Returns
     -------
@@ -834,19 +834,19 @@ def rc_imp(Ns,alpha,M=6):
     >>> plt.show()
     """
     # Design the filter
-    n = np.arange(-M*Ns,M*Ns+1)
+    n = np.arange(-m * ns, m * ns + 1)
     b = np.zeros(len(n))
     a = alpha
-    Ns *= 1.0
+    ns *= 1.0
     for i in range(len(n)):
-        if (1 - 4*(a*n[i]/Ns)**2) == 0:
+        if (1 - 4 * (a * n[i] / ns) ** 2) == 0:
             b[i] = np.pi/4*np.sinc(1/(2.*a))
         else:
-            b[i] = np.sinc(n[i]/Ns)*np.cos(np.pi*a*n[i]/Ns)/(1 - 4*(a*n[i]/Ns)**2)
+            b[i] = np.sinc(n[i] / ns) * np.cos(np.pi * a * n[i] / ns) / (1 - 4 * (a * n[i] / ns) ** 2)
     return b
 
 
-def sqrt_rc_imp(Ns,alpha,M=6):
+def sqrt_rc_imp(ns, alpha, m=6):
     """
     A truncated square root raised cosine pulse used in digital communications.
 
@@ -856,9 +856,9 @@ def sqrt_rc_imp(Ns,alpha,M=6):
 
     Parameters
     ----------
-    Ns : number of samples per symbol
+    ns : number of samples per symbol
     alpha : excess bandwidth factor on (0, 1), e.g., 0.35
-    M : equals RC one-sided symbol truncation factor
+    m : equals RC one-sided symbol truncation factor
 
     Returns
     -------
@@ -887,20 +887,20 @@ def sqrt_rc_imp(Ns,alpha,M=6):
     >>> plt.show()
     """
     # Design the filter
-    n = np.arange(-M*Ns,M*Ns+1)
+    n = np.arange(-m * ns, m * ns + 1)
     b = np.zeros(len(n))
-    Ns *= 1.0
+    ns *= 1.0
     a = alpha
     for i in range(len(n)):
-       if abs(1 - 16*a**2*(n[i]/Ns)**2) <= np.finfo(np.float).eps/2:
+       if abs(1 - 16 * a ** 2 * (n[i] / ns) ** 2) <= np.finfo(np.float).eps/2:
            b[i] = 1/2.*((1+a)*np.sin((1+a)*np.pi/(4.*a))-(1-a)*np.cos((1-a)*np.pi/(4.*a))+(4*a)/np.pi*np.sin((1-a)*np.pi/(4.*a)))
        else:
-           b[i] = 4*a/(np.pi*(1 - 16*a**2*(n[i]/Ns)**2))
-           b[i] = b[i]*(np.cos((1+a)*np.pi*n[i]/Ns) + np.sinc((1-a)*n[i]/Ns)*(1-a)*np.pi/(4.*a))
+           b[i] = 4*a/(np.pi * (1 - 16 * a ** 2 * (n[i] / ns) ** 2))
+           b[i] = b[i]*(np.cos((1+a) * np.pi * n[i] / ns) + np.sinc((1 - a) * n[i] / ns) * (1 - a) * np.pi / (4. * a))
     return b    
 
 
-def RZ_bits(N_bits,Ns,pulse='rect',alpha = 0.25,M=6):
+def rz_bits(n_bits, ns, pulse='rect', alpha=0.25, m=6):
     """
     Generate return-to-zero (RZ) data bits with pulse shaping.
 
@@ -909,11 +909,11 @@ def RZ_bits(N_bits,Ns,pulse='rect',alpha = 0.25,M=6):
 
     Parameters
     ----------
-    N_bits : number of RZ {0,1} data bits to produce
-    Ns : the number of samples per bit,
-    pulse_type : 'rect' , 'rc', 'src' (default 'rect')
+    n_bits : number of RZ {0,1} data bits to produce
+    ns : the number of samples per bit,
+    pulse : 'rect' , 'rc', 'src' (default 'rect')
     alpha : excess bandwidth factor(default 0.25)
-    M : single sided pulse duration (default = 6) 
+    m : single sided pulse duration (default = 6)
 
     Returns
     -------
@@ -931,26 +931,26 @@ def RZ_bits(N_bits,Ns,pulse='rect',alpha = 0.25,M=6):
     --------
     >>> import matplotlib.pyplot as plt
     >>> from numpy import arange
-    >>> from sk_dsp_comm.digitalcom import RZ_bits
-    >>> x,b,data = RZ_bits(100,10)
+    >>> from sk_dsp_comm.digitalcom import rz_bits
+    >>> x,b,data = rz_bits(100,10)
     >>> t = arange(len(x))
     >>> plt.plot(t,x)
     >>> plt.ylim([-0.01, 1.01])
     >>> plt.show()
     """
-    data = np.random.randint(0,2,N_bits) 
-    x = np.hstack((data.reshape(N_bits,1),np.zeros((N_bits,int(Ns)-1))))
+    data = np.random.randint(0, 2, n_bits)
+    x = np.hstack((data.reshape(n_bits, 1), np.zeros((n_bits, int(ns) - 1))))
     x =x.flatten()
     if pulse.lower() == 'rect':
-        b = np.ones(int(Ns))
+        b = np.ones(int(ns))
     elif pulse.lower() == 'rc':
-        b = rc_imp(Ns,alpha,M)
+        b = rc_imp(ns, alpha, m)
     elif pulse.lower() == 'src':
-        b = sqrt_rc_imp(Ns,alpha,M)
+        b = sqrt_rc_imp(ns, alpha, m)
     else:
         warnings.warn('pulse type must be rec, rc, or src')
     x = signal.lfilter(b,1,x)
-    return x,b/float(Ns),data
+    return x, b / float(ns), data
 
 
 def my_psd(x,NFFT=2**10,Fs=1):
@@ -991,7 +991,7 @@ def my_psd(x,NFFT=2**10,Fs=1):
     return Px.flatten(), f
 
 
-def time_delay(x,D,N=4):
+def time_delay(x, d, n=4):
     """
     A time varying time delay which takes advantage of the Farrow structure
     for cubic interpolation:
@@ -1011,19 +1011,19 @@ def time_delay(x,D,N=4):
     Mark Wickert, February 2014
     """
 
-    if type(D) == float or type(D) == int:
+    if type(d) == float or type(d) == int:
         #Make sure D stays with in the tapped delay line bounds
-        if int(np.fix(D)) < 1:
+        if int(np.fix(d)) < 1:
             log.info('D has integer part less than one')
             exit(1)
-        if int(np.fix(D)) > N-2:
+        if int(np.fix(d)) > n-2:
             log.info('D has integer part greater than N - 2')
             exit(1)
         # Filter 4-tap input with four Farrow FIR filters
         # Since the time delay is a constant, the LTI filter
         # function from scipy.signal is convenient.
-        D_frac = D - np.fix(D)
-        Nd = int(np.fix(D))
+        D_frac = d - np.fix(d)
+        Nd = int(np.fix(d))
         b = np.zeros(Nd + 4)
         # Load Lagrange coefficients into the last four FIR taps
         b[Nd] = -(D_frac-1)*(D_frac-2)*(D_frac-3)/6.
@@ -1035,22 +1035,22 @@ def time_delay(x,D,N=4):
         y = signal.lfilter(b,[1],x)
     else:
         # Make sure D stays with in the tapped delay line bounds
-        if np.fix(np.min(D)) < 1:
+        if np.fix(np.min(d)) < 1:
             log.info('D has integer part less than one')
             exit(1)
-        if np.fix(np.max(D)) > N-2:
+        if np.fix(np.max(d)) > n-2:
             log.info('D has integer part greater than N - 2')
             exit(1)
         y = np.zeros(len(x))
-        X = np.zeros(N+1)
+        X = np.zeros(n + 1)
         # Farrow filter tap weights
         W3 = np.array([[1./6, -1./2, 1./2, -1./6]])
         W2 = np.array([[0, 1./2, -1., 1./2]])
         W1 = np.array([[-1./6, 1., -1./2, -1./3]])
         W0 = np.array([[0, 0, 1., 0]])
         for k in range(len(x)):
-            Nd = int(np.fix(D[k]))
-            mu = 1 - (D[k]-np.fix(D[k]))
+            Nd = int(np.fix(d[k]))
+            mu = 1 - (d[k] - np.fix(d[k]))
             # Form a row vector of signal samples, present and past values
             X = np.hstack((np.array(x[k]), X[:-1]))
             # Filter 4-tap input with four Farrow FIR filters
@@ -1065,7 +1065,7 @@ def time_delay(x,D,N=4):
     return y
 
 
-def xcorr(x1,x2,Nlags):
+def xcorr(x1, x2, n_lags):
     """
     r12, k = xcorr(x1,x2,Nlags), r12 and k are ndarray's
     Compute the energy normalized cross correlation between the sequences
@@ -1080,18 +1080,18 @@ def xcorr(x1,x2,Nlags):
     r12 = np.fft.ifft(X1*np.conj(X2))/np.sqrt(E1*E2)
     k = np.arange(K) - int(np.floor(K/2))
     r12 = np.fft.fftshift(r12)
-    idx = np.nonzero(np.ravel(abs(k) <= Nlags))
+    idx = np.nonzero(np.ravel(abs(k) <= n_lags))
     return r12[idx], k[idx]
 
 
-def Q_fctn(x):
+def q_fctn(x):
     """
     Gaussian Q-function
     """
     return 1./2*erfc(x/np.sqrt(2.))
 
 
-def PCM_encode(x,N_bits):
+def pcm_encode(x, n_bits):
     """
     Parameters
     ----------
@@ -1104,12 +1104,12 @@ def PCM_encode(x,N_bits):
 
     Mark Wickert, Mark 2015
     """
-    xq = np.int16(np.rint(x*2**(N_bits-1)))
-    x_bits = np.zeros((N_bits,len(xq)))
+    xq = np.int16(np.rint(x * 2 ** (n_bits - 1)))
+    x_bits = np.zeros((n_bits, len(xq)))
     for k, xk in enumerate(xq):
-        x_bits[:,k] = to_bin(xk,N_bits)
+        x_bits[:,k] = to_bin(xk, n_bits)
     # Reshape into a serial bit stream
-    x_bits = np.reshape(x_bits,(1,len(x)*N_bits),'F')
+    x_bits = np.reshape(x_bits, (1, len(x) * n_bits), 'F')
     return np.int16(x_bits.flatten())
 
 
@@ -1133,13 +1133,13 @@ def from_bin(bin_array):
     return int(np.dot(bin_array,bin_wgts))
 
 
-def PCM_decode(x_bits,N_bits):
+def pcm_decode(x_bits, n_bits):
     """
     Parameters
     ----------
     x_bits : serial bit stream of 0/1 values. The length of
              x_bits must be a multiple of N_bits
-    N_bits : bit precision of PCM samples
+    n_bits : bit precision of PCM samples
 
     Returns
     -------
@@ -1147,27 +1147,27 @@ def PCM_decode(x_bits,N_bits):
 
     Mark Wickert, March 2015
     """
-    N_samples = len(x_bits)//N_bits
+    N_samples = len(x_bits) // n_bits
     # Convert serial bit stream into parallel words with each 
     # column holdingthe N_bits binary sample value
     xrs_bits = x_bits.copy()
-    xrs_bits = np.reshape(xrs_bits,(N_bits,N_samples),'F')
+    xrs_bits = np.reshape(xrs_bits, (n_bits, N_samples), 'F')
     # Convert N_bits binary words into signed integer values
     xq = np.zeros(N_samples)
-    w = 2**np.arange(N_bits-1,-1,-1) # binary weights for bin 
+    w = 2**np.arange(n_bits - 1, -1, -1) # binary weights for bin
                                      # to dec conversion
     for k in range(N_samples):
-       xq[k] = np.dot(xrs_bits[:,k],w) - xrs_bits[0,k]*2**N_bits
-    return xq/2**(N_bits-1)
+       xq[k] = np.dot(xrs_bits[:,k],w) - xrs_bits[0,k] * 2 ** n_bits
+    return xq/2**(n_bits - 1)
 
 
-def AWGN_chan(x_bits,EBN0_dB):
+def awgn_channel(x_bits, eb_n0_dB):
     """
 
     Parameters
     ----------
     x_bits : serial bit stream of 0/1 values.
-    EBN0_dB : Energy per bit to noise power density ratio in dB of the serial bit stream sent through the AWGN channel. Frequently we equate EBN0 to SNR in link budget calculations.
+    eb_n0_dB : Energy per bit to noise power density ratio in dB of the serial bit stream sent through the AWGN channel. Frequently we equate EBN0 to SNR in link budget calculations.
 
     Returns
     -------
@@ -1177,7 +1177,7 @@ def AWGN_chan(x_bits,EBN0_dB):
     Mark Wickert, March 2015
     """
     x_bits = 2*x_bits - 1 # convert from 0/1 to -1/1 signal values
-    var_noise = 10**(-EBN0_dB/10)/2
+    var_noise = 10 ** (-eb_n0_dB / 10) / 2
     y_bits = x_bits + np.sqrt(var_noise)*np.random.randn(np.size(x_bits))
 
     # Make hard decisions
@@ -1186,14 +1186,14 @@ def AWGN_chan(x_bits,EBN0_dB):
     return y_bits
 
 
-def mux_pilot_blocks(IQ_data, Np):
+def mux_pilot_blocks(iq_data, np):
     """
     Parameters
     ----------
-    IQ_data : a 2D array of input QAM symbols with the columns
+    iq_data : a 2D array of input QAM symbols with the columns
                representing the NF carrier frequencies and each
                row the QAM symbols used to form an OFDM symbol
-    Np : the period of the pilot blocks; e.g., a pilot block is
+    np : the period of the pilot blocks; e.g., a pilot block is
                inserted every Np OFDM symbols (Np-1 OFDM data symbols
                of width Nf are inserted in between the pilot blocks.
 
@@ -1210,30 +1210,30 @@ def mux_pilot_blocks(IQ_data, Np):
     A helper function called by :func:`OFDM_tx` that inserts pilot block for use
     in channel estimation when a delay spread channel is present.
     """
-    N_OFDM = IQ_data.shape[0]
-    Npb = N_OFDM // (Np - 1)
-    N_OFDM_rem = N_OFDM - Npb * (Np - 1)
-    Nf = IQ_data.shape[1]
+    N_OFDM = iq_data.shape[0]
+    Npb = N_OFDM // (np - 1)
+    N_OFDM_rem = N_OFDM - Npb * (np - 1)
+    Nf = iq_data.shape[1]
     IQ_datap = np.zeros((N_OFDM + Npb + 1, Nf), dtype=np.complex128)
     pilots = np.ones(Nf)  # The pilot symbol is simply 1 + j0
     for k in range(Npb):
-        IQ_datap[Np * k:Np * (k + 1), :] = np.vstack((pilots,
-                                                      IQ_data[(Np - 1) * k:(Np - 1) * (k + 1), :]))
-    IQ_datap[Np * Npb:Np * (Npb + N_OFDM_rem), :] = np.vstack((pilots,
-                                                               IQ_data[(Np - 1) * Npb:, :]))
+        IQ_datap[np * k:np * (k + 1), :] = np.vstack((pilots,
+                                                      iq_data[(np - 1) * k:(np - 1) * (k + 1), :]))
+    IQ_datap[np * Npb:np * (Npb + N_OFDM_rem), :] = np.vstack((pilots,
+                                                               iq_data[(np - 1) * Npb:, :]))
     return IQ_datap
 
 
-def OFDM_tx(IQ_data, Nf, N, Np=0, cp=False, Ncp=0):
+def ofdm_tx(iq_data, nf, n, np=0, cp=False, ncp=0):
     """
     Parameters
     ----------
-    IQ_data : +/-1, +/-3, etc complex QAM symbol sample inputs
-    Nf : number of filled carriers, must be even and Nf < N
-    N : total number of carriers; generally a power 2, e.g., 64, 1024, etc
-    Np : Period of pilot code blocks; 0 <=> no pilots
+    iq_data : +/-1, +/-3, etc complex QAM symbol sample inputs
+    nf : number of filled carriers, must be even and Nf < N
+    n : total number of carriers; generally a power 2, e.g., 64, 1024, etc
+    np : Period of pilot code blocks; 0 <=> no pilots
     cp : False/True <=> bypass cp insertion entirely if False
-    Ncp : the length of the cyclic prefix
+    ncp : the length of the cyclic prefix
 
     Returns
     -------
@@ -1247,8 +1247,8 @@ def OFDM_tx(IQ_data, Nf, N, Np=0, cp=False, Ncp=0):
     --------
     >>> import matplotlib.pyplot as plt
     >>> from sk_dsp_comm import digitalcom as dc
-    >>> x1,b1,IQ_data1 = dc.QAM_bb(50000,1,'16qam')
-    >>> x_out = dc.OFDM_tx(IQ_data1,32,64)
+    >>> x1,b1,IQ_data1 = dc.qam_bb(50000,1,'16qam')
+    >>> x_out = dc.ofdm_tx(IQ_data1,32,64)
     >>> plt.psd(x_out,2**10,1);
     >>> plt.xlabel(r'Normalized Frequency ($\omega/(2\pi)=f/f_s$)')
     >>> plt.ylim([-40,0])
@@ -1256,40 +1256,40 @@ def OFDM_tx(IQ_data, Nf, N, Np=0, cp=False, Ncp=0):
     >>> plt.show()
 
     """
-    N_symb = len(IQ_data)
-    N_OFDM = N_symb // Nf
-    IQ_data = IQ_data[:N_OFDM * Nf]
-    IQ_s2p = np.reshape(IQ_data, (N_OFDM, Nf))  # carrier symbols by column
+    N_symb = len(iq_data)
+    N_OFDM = N_symb // nf
+    iq_data = iq_data[:N_OFDM * nf]
+    IQ_s2p = np.reshape(iq_data, (N_OFDM, nf))  # carrier symbols by column
     log.info(IQ_s2p.shape)
-    if Np > 0:
-        IQ_s2p = mux_pilot_blocks(IQ_s2p, Np)
+    if np > 0:
+        IQ_s2p = mux_pilot_blocks(IQ_s2p, np)
         N_OFDM = IQ_s2p.shape[0]
         log.info(IQ_s2p.shape)
     if cp:
-        x_out = np.zeros(N_OFDM * (N + Ncp), dtype=np.complex128)
+        x_out = np.zeros(N_OFDM * (n + ncp), dtype=np.complex128)
     else:
-        x_out = np.zeros(N_OFDM * N, dtype=np.complex128)
+        x_out = np.zeros(N_OFDM * n, dtype=np.complex128)
     for k in range(N_OFDM):
-        buff = np.zeros(N, dtype=np.complex128)
-        for n in range(-Nf // 2, Nf // 2 + 1):
+        buff = np.zeros(n, dtype=np.complex128)
+        for n in range(-nf // 2, nf // 2 + 1):
             if n == 0:  # Modulate carrier f = 0
                 buff[0] = 0  # This can be a pilot carrier
             elif n > 0:  # Modulate carriers f = 1:Nf/2
                 buff[n] = IQ_s2p[k, n - 1]
             else:  # Modulate carriers f = -Nf/2:-1
-                buff[N + n] = IQ_s2p[k, Nf + n]
+                buff[n + n] = IQ_s2p[k, nf + n]
         if cp:
             # With cyclic prefix
             x_out_buff = fft.ifft(buff)
-            x_out[k * (N + Ncp):(k + 1) * (N + Ncp)] = np.concatenate((x_out_buff[N - Ncp:],
+            x_out[k * (n + ncp):(k + 1) * (n + ncp)] = np.concatenate((x_out_buff[n - ncp:],
                                                                        x_out_buff))
         else:
             # No cyclic prefix included
-            x_out[k * N:(k + 1) * N] = fft.ifft(buff)
+            x_out[k * n:(k + 1) * n] = fft.ifft(buff)
     return x_out
 
 
-def chan_est_equalize(z, Np, alpha, Ht=None):
+def chan_est_equalize(z, np, alpha, Ht=None):
     """
 
     This is a helper function for :func:`OFDM_rx` to unpack pilot blocks from
@@ -1302,7 +1302,7 @@ def chan_est_equalize(z, Np, alpha, Ht=None):
     Parameters
     ----------
     z : Input N_OFDM x Nf 2D array containing pilot blocks and OFDM data symbols.
-    Np : The pilot block period; if -1 use the known channel impulse response input to ht.
+    np : The pilot block period; if -1 use the known channel impulse response input to ht.
     alpha : The forgetting factor used to recursively estimate H_hat
     Ht : The theoretical channel frquency response to allow ideal equalization provided Ncp is adequate.
 
@@ -1314,18 +1314,18 @@ def chan_est_equalize(z, Np, alpha, Ht=None):
     Examples
     --------
     >>> from sk_dsp_comm.digitalcom import chan_est_equalize
-    >>> zz_out,H = chan_est_eq(z,Nf,Np,alpha,Ht=None)
+    >>> zz_out,H = chan_est_eq(z,np,alpha,Ht=None)
     """
     N_OFDM = z.shape[0]
     Nf = z.shape[1]
-    Npb = N_OFDM // Np
-    N_part = N_OFDM - Npb * Np - 1
+    Npb = N_OFDM // np
+    N_part = N_OFDM - Npb * np - 1
     zz_out = np.zeros_like(z)
     Hmatrix = np.zeros((N_OFDM, Nf), dtype=np.complex128)
     k_fill = 0
     k_pilot = 0
     for k in range(N_OFDM):
-        if np.mod(k, Np) == 0:  # Process pilot blocks
+        if np.mod(k, np) == 0:  # Process pilot blocks
             if k == 0:
                 H = z[k, :]
             else:
@@ -1359,18 +1359,18 @@ def chan_est_equalize(z, Np, alpha, Ht=None):
     return zz_out, H
 
 
-def OFDM_rx(x, Nf, N, Np=0, cp=False, Ncp=0, alpha=0.95, ht=None):
+def ofdm_rx(x, nf, n, np=0, cp=False, ncp=0, alpha=0.95, ht=None):
     """
     Parameters
     ----------
     x : Received complex baseband OFDM signal
-    Nf : Number of filled carriers, must be even and Nf < N
-    N : Total number of carriers; generally a power 2, e.g., 64, 1024, etc
-    Np : Period of pilot code blocks; 0 <=> no pilots; -1 <=> use the ht impulse response input to equalize the OFDM symbols; note equalization still requires Ncp > 0 to work on a delay spread channel.
+    nf : Number of filled carriers, must be even and Nf < N
+    n : Total number of carriers; generally a power 2, e.g., 64, 1024, etc
+    np : Period of pilot code blocks; 0 <=> no pilots; -1 <=> use the ht impulse response input to equalize the OFDM symbols; note equalization still requires Ncp > 0 to work on a delay spread channel.
     cp : False/True <=> if False assume no CP is present
-    Ncp : The length of the cyclic prefix
+    ncp : The length of the cyclic prefix
     alpha : The filter forgetting factor in the channel estimator. Typically alpha is 0.9 to 0.99.
-    nt : Input the known theoretical channel impulse response
+    ht : Input the known theoretical channel impulse response
 
     Returns
     -------
@@ -1390,11 +1390,11 @@ def OFDM_rx(x, Nf, N, Np=0, cp=False, Ncp=0, alpha=0.95, ht=None):
     >>> from numpy import array
     >>> hc = array([1.0, 0.1, -0.05, 0.15, 0.2, 0.05]) # impulse response spanning five symbols
     >>> # Quick example using the above channel with no cyclic prefix
-    >>> x1,b1,IQ_data1 = dc.QAM_bb(50000,1,'16qam')
-    >>> x_out = dc.OFDM_tx(IQ_data1,32,64,0,True,0)
+    >>> x1,b1,IQ_data1 = dc.qam_bb(50000,1,'16qam')
+    >>> x_out = dc.ofdm_tx(IQ_data1,32,64,0,True,0)
     >>> c_out = signal.lfilter(hc,1,x_out) # Apply channel distortion
     >>> r_out = dc.cpx_awgn(c_out,100,64/32) # Es/N0 = 100 dB
-    >>> z_out,H = dc.OFDM_rx(r_out,32,64,-1,True,0,alpha=0.95,ht=hc)
+    >>> z_out,H = dc.ofdm_rx(r_out,32,64,-1,True,0,alpha=0.95,ht=hc)
     >>> plt.plot(z_out[200:].real,z_out[200:].imag,'.')
     >>> plt.xlabel('In-Phase')
     >>> plt.ylabel('Quadrature')
@@ -1404,10 +1404,10 @@ def OFDM_rx(x, Nf, N, Np=0, cp=False, Ncp=0, alpha=0.95, ht=None):
 
     Another example with noise using a 10 symbol cyclic prefix and channel estimation:
 
-    >>> x_out = dc.OFDM_tx(IQ_data1,32,64,100,True,10)
+    >>> x_out = dc.ofdm_tx(IQ_data1,32,64,100,True,10)
     >>> c_out = signal.lfilter(hc,1,x_out) # Apply channel distortion
     >>> r_out = dc.cpx_awgn(c_out,25,64/32) # Es/N0 = 25 dB
-    >>> z_out,H = dc.OFDM_rx(r_out,32,64,100,True,10,alpha=0.95,ht=hc);
+    >>> z_out,H = dc.ofdm_rx(r_out,32,64,100,True,10,alpha=0.95,ht=hc);
     >>> plt.figure() # if channel estimation is turned on need this
     >>> plt.plot(z_out[-2000:].real,z_out[-2000:].imag,'.') # allow settling time
     >>> plt.xlabel('In-Phase')
@@ -1417,33 +1417,33 @@ def OFDM_rx(x, Nf, N, Np=0, cp=False, Ncp=0, alpha=0.95, ht=None):
     >>> plt.show()
 
     """
-    N_symb = len(x) // (N + Ncp)
-    y_out = np.zeros(N_symb * N, dtype=np.complex128)
+    N_symb = len(x) // (n + ncp)
+    y_out = np.zeros(N_symb * n, dtype=np.complex128)
     for k in range(N_symb):
         if cp:
             # Remove the cyclic prefix
-            buff = x[k * (N + Ncp) + Ncp:(k + 1) * (N + Ncp)]
+            buff = x[k * (n + ncp) + ncp:(k + 1) * (n + ncp)]
         else:
-            buff = x[k * N:(k + 1) * N]
-        y_out[k * N:(k + 1) * N] = fft.fft(buff)
+            buff = x[k * n:(k + 1) * n]
+        y_out[k * n:(k + 1) * n] = fft.fft(buff)
     # Demultiplex into Nf parallel streams from N total, including
     # the pilot blocks which contain channel information
-    z_out = np.reshape(y_out, (N_symb, N))
-    z_out = np.hstack((z_out[:, 1:Nf // 2 + 1], z_out[:, N - Nf // 2:N]))
-    if Np > 0:
+    z_out = np.reshape(y_out, (N_symb, n))
+    z_out = np.hstack((z_out[:, 1:nf // 2 + 1], z_out[:, n - nf // 2:n]))
+    if np > 0:
         if isinstance(type(None), type(ht)):
-            z_out, H = chan_est_equalize(z_out, Np, alpha)
+            z_out, H = chan_est_equalize(z_out, np, alpha)
         else:
-            Ht = fft.fft(ht, N)
-            Hht = np.hstack((Ht[1:Nf // 2 + 1], Ht[N - Nf // 2:]))
-            z_out, H = chan_est_equalize(z_out, Np, alpha, Hht)
-    elif Np == -1:  # Ideal equalization using hc
-        Ht = fft.fft(ht, N)
-        H = np.hstack((Ht[1:Nf // 2 + 1], Ht[N - Nf // 2:]))
+            Ht = fft.fft(ht, n)
+            Hht = np.hstack((Ht[1:nf // 2 + 1], Ht[n - nf // 2:]))
+            z_out, H = chan_est_equalize(z_out, np, alpha, Hht)
+    elif np == -1:  # Ideal equalization using hc
+        Ht = fft.fft(ht, n)
+        H = np.hstack((Ht[1:nf // 2 + 1], Ht[n - nf // 2:]))
         for k in range(N_symb):
             z_out[k, :] /= H
     else:
-        H = np.ones(Nf)
+        H = np.ones(nf)
     # Multiplex into original serial symbol stream
     return z_out.flatten(), H
 
@@ -1482,16 +1482,16 @@ def gray2bin(d_word,b_width):
     return from_bin(bits_out)
 
 
-def QAM_gray_encode_bb(N_symb,Ns,M=4,pulse='rect',alpha=0.35,M_span=6,ext_data=None):
+def qam_gray_encode_bb(n_symb, ns, mod=4, pulse='rect', alpha=0.35, m_span=6, ext_data=None):
     """
     QAM_gray_bb: A gray code mapped QAM complex baseband transmitter 
     x,b,tx_data = QAM_gray_bb(K,Ns,M)
     
     Parameters
     ----------
-    N_symb : The number of symbols to process
-    Ns : Number of samples per symbol
-    M : Modulation order: 2, 4, 16, 64, 256 QAM. Note 2 <=> BPSK, 4 <=> QPSK
+    n_symb : The number of symbols to process
+    ns : Number of samples per symbol
+    mod : Modulation order: 2, 4, 16, 64, 256 QAM. Note 2 <=> BPSK, 4 <=> QPSK
     alpha : Square root raised cosine excess bandwidth factor.
             For DOCSIS alpha = 0.12 to 0.18. In general alpha can range over 0 < alpha < 1.
     pulse : 'rect', 'src', or 'rc'
@@ -1519,42 +1519,42 @@ def QAM_gray_encode_bb(N_symb,Ns,M=4,pulse='rect',alpha=0.35,M_span=6,ext_data=N
     bin2gray2 = [0,1,3,2]
     bin2gray3 = [0,1,3,2,7,6,4,5] # arange(8) 
     bin2gray4 = [0,1,3,2,7,6,4,5,15,14,12,13,8,9,11,10]
-    x_m = np.sqrt(M)-1
+    x_m = np.sqrt(mod) - 1
     # Create the serial bit stream [Ibits,Qbits,Ibits,Qbits,...], msb to lsb
     # except for the case M = 2
-    if N_symb == None:
+    if n_symb == None:
         # Truncate so an integer number of symbols is formed
-        N_symb = int(np.floor(len(ext_data)/np.log2(M)))
-        data = ext_data[:N_symb*int(np.log2(M))]
+        n_symb = int(np.floor(len(ext_data) / np.log2(mod)))
+        data = ext_data[:n_symb * int(np.log2(mod))]
     else:
-        data = np.random.randint(0,2,size=int(np.log2(M))*N_symb)
-    x_IQ = np.zeros(N_symb,dtype=np.complex128)
-    N_word = int(np.log2(M)/2)
+        data = np.random.randint(0, 2, size=int(np.log2(mod)) * n_symb)
+    x_IQ = np.zeros(n_symb, dtype=np.complex128)
+    N_word = int(np.log2(mod) / 2)
     # binary weights for converting binary to decimal using dot()
     w = 2**np.arange(N_word-1,-1,-1)
-    if M == 2: # Special case of BPSK for convenience
+    if mod == 2: # Special case of BPSK for convenience
         x_IQ = 2*data - 1
         x_m = 1
-    elif M == 4: # total constellation points
-        for k in range(N_symb):
+    elif mod == 4: # total constellation points
+        for k in range(n_symb):
             wordI = data[2*k*N_word:(2*k+1)*N_word]
             wordQ = data[2*k*N_word+N_word:(2*k+1)*N_word+N_word]
             x_IQ[k] = (2*bin2gray1[np.dot(wordI,w)] - x_m) + \
                    1j*(2*bin2gray1[np.dot(wordQ,w)] - x_m)
-    elif M == 16:
-        for k in range(N_symb):
+    elif mod == 16:
+        for k in range(n_symb):
             wordI = data[2*k*N_word:(2*k+1)*N_word]
             wordQ = data[2*k*N_word+N_word:(2*k+1)*N_word+N_word]
             x_IQ[k] = (2*bin2gray2[np.dot(wordI,w)] - x_m) + \
                    1j*(2*bin2gray2[np.dot(wordQ,w)] - x_m)
-    elif M == 64:
-        for k in range(N_symb):
+    elif mod == 64:
+        for k in range(n_symb):
             wordI = data[2*k*N_word:(2*k+1)*N_word]
             wordQ = data[2*k*N_word+N_word:(2*k+1)*N_word+N_word]
             x_IQ[k] = (2*bin2gray3[np.dot(wordI,w)] - x_m) + \
                    1j*(2*bin2gray3[np.dot(wordQ,w)] - x_m)
-    elif M == 256:
-        for k in range(N_symb):
+    elif mod == 256:
+        for k in range(n_symb):
             wordI = data[2*k*N_word:(2*k+1)*N_word]
             wordQ = data[2*k*N_word+N_word:(2*k+1)*N_word+N_word]
             x_IQ[k] = (2*bin2gray4[np.dot(wordI,w)] - x_m) + \
@@ -1562,19 +1562,19 @@ def QAM_gray_encode_bb(N_symb,Ns,M=4,pulse='rect',alpha=0.35,M_span=6,ext_data=N
     else:
         raise ValueError('M must be 2, 4, 16, 64, 256')        
     
-    if Ns > 1:
+    if ns > 1:
         # Design the pulse shaping filter to be of duration 12 
         # symbols and fix the excess bandwidth factor at alpha = 0.35
         if pulse.lower() == 'src':
-            b = sqrt_rc_imp(Ns,alpha,M_span)
+            b = sqrt_rc_imp(ns, alpha, m_span)
         elif pulse.lower() == 'rc':
-            b = rc_imp(Ns,alpha,M_span)    
+            b = rc_imp(ns, alpha, m_span)
         elif pulse.lower() == 'rect':
-            b = np.ones(int(Ns)) #alt. rect. pulse shape
+            b = np.ones(int(ns)) #alt. rect. pulse shape
         else:
             raise ValueError('pulse shape must be src, rc, or rect')
         # Filter the impulse train signal
-        x = signal.lfilter(b,1,upsample(x_IQ,Ns))
+        x = signal.lfilter(b, 1, upsample(x_IQ, ns))
         # Scale shaping filter to have unity DC gain
         b = b/sum(b)
         return x/x_m, b, data
@@ -1582,7 +1582,7 @@ def QAM_gray_encode_bb(N_symb,Ns,M=4,pulse='rect',alpha=0.35,M_span=6,ext_data=N
         return x_IQ/x_m, 1, data
 
 
-def QAM_gray_decode(x_hat,M = 4):
+def qam_gray_decode(x_hat, mod=4):
     """
     Decode MQAM IQ symbols to a serial bit stream using
     gray2bin decoding
@@ -1598,16 +1598,16 @@ def QAM_gray_decode(x_hat,M = 4):
     gray2bin2 = [0,1,3,2]
     gray2bin3 = [0,1,3,2,6,7,5,4] # arange(8) 
     gray2bin4 = [0,1,3,2,6,7,5,4,12,13,15,14,10,11,9,8]
-    x_m = np.sqrt(M)-1
-    if M == 2: x_m = 1
+    x_m = np.sqrt(mod) - 1
+    if mod == 2: x_m = 1
     N_symb = len(x_hat)
-    N_word = int(np.log2(M)/2)
+    N_word = int(np.log2(mod) / 2)
     
     # Scale input up by x_m
     #x_hat = x_hat*x_m
     # Scale adaptively assuming var(x_hat) is proportional to 
     # signal power using a known relationship for QAM.
-    x_hat = x_hat/(np.std(x_hat) * np.sqrt(3/(2*(M-1))))
+    x_hat = x_hat/(np.std(x_hat) * np.sqrt(3 / (2 * (mod - 1))))
     
     k_hat_gray = (x_hat + x_m*(1+1j))/2
     # Soft IQ symbol values are converted to hard symbol decisions
@@ -1616,21 +1616,21 @@ def QAM_gray_decode(x_hat,M = 4):
     data_hat = np.zeros(2*N_word*N_symb,dtype=int)
     # Create the serial bit stream [Ibits,Qbits,Ibits,Qbits,...], msb to lsb
     for k in range(N_symb):
-        if M == 2: # special case for BPSK
+        if mod == 2: # special case for BPSK
             data_hat = k_hat_grayI
-        elif M == 4: # total points of the square constellation
+        elif mod == 4: # total points of the square constellation
             data_hat[2*k*N_word:2*(k+1)*N_word] \
               = np.hstack((to_bin(gray2bin1[k_hat_grayI[k]],N_word),
                         to_bin(gray2bin1[k_hat_grayQ[k]],N_word)))
-        elif M == 16:
+        elif mod == 16:
             data_hat[2*k*N_word:2*(k+1)*N_word] \
               = np.hstack((to_bin(gray2bin2[k_hat_grayI[k]],N_word),
                         to_bin(gray2bin2[k_hat_grayQ[k]],N_word)))            
-        elif M == 64:
+        elif mod == 64:
             data_hat[2*k*N_word:2*(k+1)*N_word] \
               = np.hstack((to_bin(gray2bin3[k_hat_grayI[k]],N_word),
                         to_bin(gray2bin3[k_hat_grayQ[k]],N_word)))            
-        elif M == 256:
+        elif mod == 256:
             data_hat[2*k*N_word:2*(k+1)*N_word] \
               = np.hstack((to_bin(gray2bin4[k_hat_grayI[k]],N_word),
                         to_bin(gray2bin4[k_hat_grayQ[k]],N_word)))
@@ -1640,23 +1640,24 @@ def QAM_gray_decode(x_hat,M = 4):
     return data_hat
 
 
-def MPSK_gray_encode_bb(N_symb,Ns,M=4,pulse='rect',alpha=0.35,M_span=6,ext_data=None):
+def mpsk_gray_encode_bb(n_symb, ns, mod=4, pulse='rect', alpha=0.35, m_span=6, ext_data=None):
     """
     MPSK_gray_bb: A gray code mapped MPSK complex baseband transmitter 
     x,b,tx_data = MPSK_gray_bb(K,Ns,M)
 
-    //////////// Inputs //////////////////////////////////////////////////
-      N_symb = the number of symbols to process
-          Ns = number of samples per symbol
-           M = modulation order: 2, 4, 8, 16 MPSK
-       alpha = squareroot raised cosine excess bandwidth factor.
-               Can range over 0 < alpha < 1.
-       pulse = 'rect', 'src', or 'rc'
-    //////////// Outputs /////////////////////////////////////////////////
-           x = complex baseband digital modulation
-           b = transmitter shaping filter, rectangle or SRC
-     tx_data = xI+1j*xQ = inphase symbol sequence + 
-               1j*quadrature symbol sequence
+    Parameters
+    ----------
+    n_symb : the number of symbols to process
+    ns : number of samples per symbol
+    mod : modulation order: 2, 4, 8, 16 MPSK
+    alpha : squareroot raised cosine excess bandwidth factor. Can range over 0 < alpha < 1.
+    pulse : 'rect', 'src', or 'rc'
+
+    Returns
+    -------
+    x : complex baseband digital modulation
+    b : transmitter shaping filter, rectangle or SRC
+    tx_data : xI+1j*xQ = inphase symbol sequence + 1j*quadrature symbol sequence
 
     Mark Wickert November 2018
     """ 
@@ -1671,54 +1672,54 @@ def MPSK_gray_encode_bb(N_symb,Ns,M=4,pulse='rect',alpha=0.35,M_span=6,ext_data=
                  28,29,24,25,27,26,16,17,19,18,23,22,20,21]
     # Create the serial bit stream msb to lsb
     # except for the case M = 2
-    N_word = int(np.log2(M))
-    if N_symb == None:
+    N_word = int(np.log2(mod))
+    if n_symb == None:
         # Truncate so an integer number of symbols is formed
-        N_symb = int(np.floor(len(ext_data)/N_word))
-        data = ext_data[:N_symb*N_word]
+        n_symb = int(np.floor(len(ext_data) / N_word))
+        data = ext_data[:n_symb * N_word]
     else:
-        data = np.random.randint(0,2,size=int(np.log2(M))*N_symb)
-    x_IQ = np.zeros(N_symb,dtype=np.complex128)
+        data = np.random.randint(0, 2, size=int(np.log2(mod)) * n_symb)
+    x_IQ = np.zeros(n_symb, dtype=np.complex128)
     # binary weights for converting binary to decimal using dot()
     bin_wgts = 2**np.arange(N_word-1,-1,-1)
-    if M == 2: # Special case of BPSK for convenience
+    if mod == 2: # Special case of BPSK for convenience
         x_IQ = 2*data - 1
-    elif M == 4: # total constellation points
-        for k in range(N_symb):
+    elif mod == 4: # total constellation points
+        for k in range(n_symb):
             word_phase = data[k*N_word:(k+1)*N_word]
-            x_phase = 2*np.pi*bin2gray2[np.dot(word_phase,bin_wgts)]/M + np.pi/M
+            x_phase = 2 * np.pi * bin2gray2[np.dot(word_phase,bin_wgts)] / mod + np.pi / mod
             x_IQ[k] = np.exp(1j*x_phase)
-    elif M == 8:
-        for k in range(N_symb):
+    elif mod == 8:
+        for k in range(n_symb):
             word_phase = data[k*N_word:(k+1)*N_word]
-            x_phase = 2*np.pi*bin2gray3[np.dot(word_phase,bin_wgts)]/M
+            x_phase = 2 * np.pi * bin2gray3[np.dot(word_phase,bin_wgts)] / mod
             x_IQ[k] = np.exp(1j*x_phase)
-    elif M == 16:
-        for k in range(N_symb):
+    elif mod == 16:
+        for k in range(n_symb):
             word_phase = data[k*N_word:(k+1)*N_word]
-            x_phase = 2*np.pi*bin2gray4[np.dot(word_phase,bin_wgts)]/M
+            x_phase = 2 * np.pi * bin2gray4[np.dot(word_phase,bin_wgts)] / mod
             x_IQ[k] = np.exp(1j*x_phase)
-    elif M == 32:
-        for k in range(N_symb):
+    elif mod == 32:
+        for k in range(n_symb):
             word_phase = data[k*N_word:(k+1)*N_word]
-            x_phase = 2*np.pi*bin2gray5[np.dot(word_phase,bin_wgts)]/M
+            x_phase = 2 * np.pi * bin2gray5[np.dot(word_phase,bin_wgts)] / mod
             x_IQ[k] = np.exp(1j*x_phase)
     else:
         raise ValueError('M must be 2, 4, 8, 16, or 32')        
     
-    if Ns > 1:
+    if ns > 1:
         # Design the pulse shaping filter to be of duration 12 
         # symbols and fix the excess bandwidth factor at alpha = 0.35
         if pulse.lower() == 'src':
-            b = sqrt_rc_imp(Ns,alpha,M_span)
+            b = sqrt_rc_imp(ns, alpha, m_span)
         elif pulse.lower() == 'rc':
-            b = rc_imp(Ns,alpha,M_span)    
+            b = rc_imp(ns, alpha, m_span)
         elif pulse.lower() == 'rect':
-            b = np.ones(int(Ns)) #alt. rect. pulse shape
+            b = np.ones(int(ns)) #alt. rect. pulse shape
         else:
             raise ValueError('pulse shape must be src, rc, or rect')
         # Filter the impulse train signal
-        x = signal.lfilter(b,1,upsample(x_IQ,Ns))
+        x = signal.lfilter(b, 1, upsample(x_IQ, ns))
         # Scale shaping filter to have unity DC gain
         b = b/sum(b)
         return x, b, data
@@ -1726,13 +1727,16 @@ def MPSK_gray_encode_bb(N_symb,Ns,M=4,pulse='rect',alpha=0.35,M_span=6,ext_data=
         return x_IQ, 1, data
 
 
-def MPSK_gray_decode(x_hat,M = 4):
+def mpsk_gray_decode(x_hat, mod=4):
     """
     Decode MPSK IQ symbols to a serial bit stream using
     gray2bin decoding
     
-    x_hat = symbol spaced samples of the MPSK waveform taken at the maximum
+    Parameters
+    ----------
+    x_hat : symbol spaced samples of the MPSK waveform taken at the maximum
             eye opening. Normally this is following the matched filter
+    mod : Modulation scheme
     
     Mark Wickert November 2018
     """
@@ -1745,34 +1749,34 @@ def MPSK_gray_decode(x_hat,M = 4):
     gray2bin5 = [0,1,3,2,6,7,5,4,12,13,15,14,10,11,9,8,24,25,
                  27,26,30,31,29,28,20,21,23,22,18,19,17,16]
     N_symb = len(x_hat)
-    N_word = int(np.log2(M))
+    N_word = int(np.log2(mod))
     
    
     # Soft IQ symbol angle values are converted to hard symbol decisions as 
     # decimal angles over the range [0, M-1]
-    if M == 4:
+    if mod == 4:
         # For QPSK (M=4) rotate constellation angles to start at zero
         k_hat_gray_theta = np.mod(np.int64(np.rint(np.angle(x_hat *\
-                           np.exp(-1j*np.pi/4))*M/2/np.pi)),M)
+                           np.exp(-1j*np.pi/4)) * mod / 2 / np.pi)), mod)
     else:
         #k_hat_gray_theta = np.mod(np.int64(np.rint(np.angle(x_hat)*M/2/np.pi)),M)
-        k_hat_gray_theta = np.mod((np.rint(np.angle(x_hat)*M/2/np.pi)).astype(np.int),M)
+        k_hat_gray_theta = np.mod((np.rint(np.angle(x_hat) * mod / 2 / np.pi)).astype(np.int), mod)
 
     data_hat = np.zeros(N_symb*N_word,dtype=int)
     # Create the serial bit stream using Gray decoding, msb to lsb
     for k in range(N_symb):
-        if M == 2: # special case for BPSK
+        if mod == 2: # special case for BPSK
             data_hat[k] = k_hat_gray_theta[k]
-        elif M == 4: # total points of the square constellation
+        elif mod == 4: # total points of the square constellation
             data_hat[k*N_word:(k+1)*N_word] \
               = to_bin(gray2bin2[k_hat_gray_theta[k]],N_word)
-        elif M == 8:
+        elif mod == 8:
             data_hat[k*N_word:(k+1)*N_word] \
               = to_bin(gray2bin3[k_hat_gray_theta[k]],N_word)            
-        elif M == 16:
+        elif mod == 16:
             data_hat[k*N_word:(k+1)*N_word] \
               = to_bin(gray2bin4[k_hat_gray_theta[k]],N_word)            
-        elif M == 32:
+        elif mod == 32:
             data_hat[k*N_word:(k+1)*N_word] \
               = to_bin(gray2bin5[k_hat_gray_theta[k]],N_word)
         else:
@@ -1780,40 +1784,38 @@ def MPSK_gray_decode(x_hat,M = 4):
     return data_hat
 
 
-def MPSK_BEP_thy(SNR_dB, M, EbN0_Mode = True):
+def mpsk_bep_thy(snr_dB, mod, eb_n0_mode=True):
     """
     Approximate the bit error probability of MPSK assuming Gray encoding
     
     Mark Wickert November 2018
     """
-    if EbN0_Mode:
-        EsN0_dB = SNR_dB + 10*np.log10(np.log2(M))
+    if eb_n0_mode:
+        EsN0_dB = snr_dB + 10 * np.log10(np.log2(mod))
     else:
-        EsN0_dB = SNR_dB
-    Symb2Bits = np.log2(M)
-    if M == 2:
-        BEP = Q_fctn(np.sqrt(2*10**(EsN0_dB/10)))
+        EsN0_dB = snr_dB
+    Symb2Bits = np.log2(mod)
+    if mod == 2:
+        BEP = q_fctn(np.sqrt(2 * 10 ** (EsN0_dB / 10)))
     else:
-        SEP = 2*Q_fctn(np.sqrt(2*10**(EsN0_dB/10))*np.sin(np.pi/M))
+        SEP = 2 * q_fctn(np.sqrt(2 * 10 ** (EsN0_dB / 10)) * np.sin(np.pi / mod))
         BEP = SEP/Symb2Bits
     return BEP 
 
 
-def QAM_BEP_thy(SNR_dB,M,EbN0_Mode = True):
+def qam_bep_thy(snr_dB, mod, eb_n0_mode=True):
     """
     Approximate the bit error probability of QAM assuming Gray encoding
     
     Mark Wickert November 2018
     """
-    if EbN0_Mode:
-        EsN0_dB = SNR_dB + 10*np.log10(np.log2(M))
+    if eb_n0_mode:
+        EsN0_dB = snr_dB + 10 * np.log10(np.log2(mod))
     else:
-        EsN0_dB = SNR_dB
-    if M == 2:
-        BEP = Q_fctn(np.sqrt(2*10**(EsN0_dB/10)))
-    elif M > 2:
-        SEP = 4*(1 - 1/np.sqrt(M))*Q_fctn(np.sqrt(3/(M-1)*10**(EsN0_dB/10)))
-        BEP = SEP/np.log2(M)
+        EsN0_dB = snr_dB
+    if mod == 2:
+        BEP = q_fctn(np.sqrt(2 * 10 ** (EsN0_dB / 10)))
+    elif mod > 2:
+        SEP = 4 * (1 - 1 / np.sqrt(mod)) * q_fctn(np.sqrt(3 / (mod - 1) * 10 ** (EsN0_dB / 10)))
+        BEP = SEP/np.log2(mod)
     return BEP
-
-

--- a/sk_dsp_comm/digitalcom.py
+++ b/sk_dsp_comm/digitalcom.py
@@ -274,6 +274,11 @@ def bit_errors(tx_data, rx_data, n_corr=1024, n_transient=0):
     tx_data : ndarray of 0/1 bits as real numbers I.
     rx_data : ndarray of 0/1 bits as real numbers I.
 
+    Returns:
+    --------
+    bit_count : Number of bits processed
+    bit_errors : Number of bit errors found
+
     Notes:
     ------
     n_corr needs to be even.
@@ -1099,11 +1104,11 @@ def pcm_encode(x, n_bits):
     Parameters
     ----------
     x : signal samples to be PCM encoded
-    N_bits ; bit precision of PCM samples
+    n_bits : bit precision of PCM samples
 
     Returns
     -------
-    x_bits = encoded serial bit stream of 0/1 values. MSB first.
+    x_bits : encoded serial bit stream of 0/1 values. MSB first.
 
     Mark Wickert, Mark 2015
     """

--- a/sk_dsp_comm/digitalcom.py
+++ b/sk_dsp_comm/digitalcom.py
@@ -184,7 +184,7 @@ def eye_plot(x, l, s=0):
     plt.plot(idx, x[s:s + l + 1], 'b')
     k_max = int((len(x) - s) / l) - 1
     for k in range(1,k_max):
-         plt.plot(idx, x[s + k * l:s + l + 1 + k * l], 'b')
+        plt.plot(idx, x[s + k * l:s + l + 1 + k * l], 'b')
     plt.grid()
     plt.xlabel('Time Index - n')
     plt.ylabel('Amplitude')
@@ -325,21 +325,23 @@ def bit_errors(tx_data, rx_data, n_corr=1024, n_transient=0):
 
 def qam_bb(n_symb, ns, mod='16qam', pulse='rect', alpha=0.35):
     """
-    QAM_BB_TX: A complex baseband transmitter 
-    x,b,tx_data = QAM_bb(K,Ns,M)
+    A complex baseband transmitter
 
-    //////////// Inputs //////////////////////////////////////////////////
-      N_symb = the number of symbols to process
-          Ns = number of samples per symbol
-    mod_type = modulation type: qpsk, 16qam, 64qam, or 256qam
-       alpha = squareroot raised codine pulse shape bandwidth factor.
+    Parameters
+    ----------
+    n_symb : the number of symbols to process
+    ns : number of samples per symbol
+    mod : modulation type: qpsk, 16qam, 64qam, or 256qam
+    alpha : squareroot raised codine pulse shape bandwidth factor.
                For DOCSIS alpha = 0.12 to 0.18. In general alpha can 
                range over 0 < alpha < 1.
-         SRC = pulse shape: 0-> rect, 1-> SRC
-    //////////// Outputs /////////////////////////////////////////////////
-           x = complex baseband digital modulation
-           b = transmitter shaping filter, rectangle or SRC
-     tx_data = xI+1j*xQ = inphase symbol sequence + 
+    pulse: pulse shapes: src, rc, rect
+
+    Returns
+    -------
+    x : complex baseband digital modulation
+    b : transmitter shaping filter, rectangle or SRC
+    tx_data : xI+1j*xQ = inphase symbol sequence +
                1j*quadrature symbol sequence
 
     Mark Wickert November 2014

--- a/sk_dsp_comm/fec_block.py
+++ b/sk_dsp_comm/fec_block.py
@@ -52,7 +52,7 @@ Mark Wickert and Andrew Smit: October 2018.
 
 import numpy as np
 import scipy.special as special
-from .digitalcom import Q_fctn
+from .digitalcom import q_fctn
 from .fec_conv import binary
 from logging import getLogger
 log = getLogger(__name__)
@@ -483,13 +483,13 @@ def block_single_error_Pb_bound(j,SNRdB,coded=True,M=2):
     for i,SNRn in enumerate(SNR):
         if coded: # compute Hamming code Ps
             if M == 2:
-                Ps[i] = Q_fctn(np.sqrt(k*2.*SNRn/n))
+                Ps[i] = q_fctn(np.sqrt(k * 2. * SNRn / n))
             else:
                 Ps[i] = 4./np.log2(M)*(1 - 1/np.sqrt(M))*\
                         np.gaussQ(np.sqrt(3*np.log2(M)/(M-1)*SNRn))/k
         else: # Compute Uncoded Pb
             if M == 2:
-                Pb[i] = Q_fctn(np.sqrt(2.*SNRn))
+                Pb[i] = q_fctn(np.sqrt(2. * SNRn))
             else:
                 Pb[i] = 4./np.log2(M)*(1 - 1/np.sqrt(M))*\
                         np.gaussQ(np.sqrt(3*np.log2(M)/(M-1)*SNRn))

--- a/sk_dsp_comm/fec_block.py
+++ b/sk_dsp_comm/fec_block.py
@@ -58,7 +58,7 @@ from logging import getLogger
 log = getLogger(__name__)
 
 
-class fec_hamming(object):
+class FecHamming(object):
     """
     Class responsible for creating hamming block codes and then 
     encoding and decoding. Methods provided include hamm_gen,
@@ -234,7 +234,8 @@ class fec_hamming(object):
             decoded_bits[i*self.k:(i+1)*self.k] = np.matmul(self.R,codewords[:,i*self.n:(i+1)*self.n].T).T % 2
         return decoded_bits.astype(int)
 
-class fec_cyclic(object):
+
+class FecCyclic(object):
     """
     Class responsible for creating cyclic block codes and then 
     encoding and decoding. Methods provided include

--- a/sk_dsp_comm/fec_block.py
+++ b/sk_dsp_comm/fec_block.py
@@ -58,7 +58,7 @@ from logging import getLogger
 log = getLogger(__name__)
 
 
-class FecHamming(object):
+class FECHamming(object):
     """
     Class responsible for creating hamming block codes and then 
     encoding and decoding. Methods provided include hamm_gen,
@@ -235,7 +235,7 @@ class FecHamming(object):
         return decoded_bits.astype(int)
 
 
-class FecCyclic(object):
+class FECCyclic(object):
     """
     Class responsible for creating cyclic block codes and then 
     encoding and decoding. Methods provided include

--- a/sk_dsp_comm/fec_conv.py
+++ b/sk_dsp_comm/fec_conv.py
@@ -114,7 +114,7 @@ def binary(num, length=8):
         return format(num, '0{}b'.format(length))
 
 
-class FecConv(object):
+class FECConv(object):
     """
     Class responsible for creating rate 1/2 convolutional code objects, and 
     then encoding and decoding the user code set in polynomials of G. Key
@@ -134,11 +134,11 @@ class FecConv(object):
     --------
     >>> from sk_dsp_comm import fec_conv
     >>> # Rate 1/2
-    >>> cc1 = fec_conv.FecConv(('101', '111'), Depth=10)  # decision depth is 10
+    >>> cc1 = fec_conv.FECConv(('101', '111'), Depth=10)  # decision depth is 10
 
     >>> # Rate 1/3
     >>> from sk_dsp_comm import fec_conv
-    >>> cc2 = fec_conv.FecConv(('101','011','111'), Depth=15)  # decision depth is 15
+    >>> cc2 = fec_conv.FECConv(('101','011','111'), Depth=15)  # decision depth is 15
 
     
     """
@@ -284,7 +284,7 @@ class FecConv(object):
         >>> EbN0 = 4
         >>> total_bit_errors = 0
         >>> total_bit_count = 0
-        >>> cc1 = fec.FecConv(('11101','10011'),25)
+        >>> cc1 = fec.FECConv(('11101','10011'),25)
         >>> # Encode with shift register starting state of '0000'
         >>> state = '0000'
         >>> while total_bit_errors < 100:
@@ -359,7 +359,7 @@ class FecConv(object):
         >>> EbN0 = 3
         >>> total_bit_errors = 0
         >>> total_bit_count = 0
-        >>> cc2 = fec.FecConv(('11111','11011','10101'),25)
+        >>> cc2 = fec.FECConv(('11111','11011','10101'),25)
         >>> # Encode with shift register starting state of '0000'
         >>> state = '0000'
         >>> while total_bit_errors < 100:
@@ -580,8 +580,8 @@ class FecConv(object):
         the  :math:`G_{2}`  polynomial.
 
         >>> import numpy as np
-        >>> from sk_dsp_comm.fec_conv import FecConv
-        >>> cc = FecConv(('101','111'))
+        >>> from sk_dsp_comm.fec_conv import FECConv
+        >>> cc = FECConv(('101','111'))
         >>> x = np.array([0, 0, 1, 1, 1, 0, 0, 0, 0, 0])
         >>> state = '00'
         >>> y, state = cc.conv_encoder(x, state)
@@ -651,8 +651,8 @@ class FecConv(object):
         the  :math:`G_{2}`  polynomial.
 
         >>> import numpy as np
-        >>> from sk_dsp_comm.fec_conv import FecConv
-        >>> cc = FecConv(('101','111'))
+        >>> from sk_dsp_comm.fec_conv import FECConv
+        >>> cc = FECConv(('101','111'))
         >>> x = np.array([0, 0, 1, 1, 1, 0, 0, 0, 0, 0])
         >>> state = '00'
         >>> y, state = cc.conv_encoder(x, state)
@@ -722,8 +722,8 @@ class FecConv(object):
         Examples
         --------
         >>> import matplotlib.pyplot as plt
-        >>> from sk_dsp_comm.fec_conv import FecConv
-        >>> cc = FecConv()
+        >>> from sk_dsp_comm.fec_conv import FECConv
+        >>> cc = FECConv()
         >>> cc.trellis_plot()
         >>> plt.show()
         """
@@ -763,10 +763,10 @@ class FecConv(object):
         Examples
         --------
         >>> import matplotlib.pyplot as plt
-        >>> from sk_dsp_comm.fec_conv import FecConv
+        >>> from sk_dsp_comm.fec_conv import FECConv
         >>> from sk_dsp_comm import digitalcom as dc
         >>> import numpy as np
-        >>> cc = FecConv()
+        >>> cc = FECConv()
         >>> x = np.random.randint(0,2,100)
         >>> state = '00'
         >>> y,state = cc.conv_encoder(x,state)
@@ -910,7 +910,7 @@ if __name__ == '__main__':
          0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 1,
          1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0, 1,
          0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1]
-    cc1 = FecConv()
+    cc1 = FECConv()
     output, states = cc1.conv_encoder(x,'00')
     y = cc1.viterbi_decoder(7*output,'three_bit')
     

--- a/sk_dsp_comm/fec_conv.py
+++ b/sk_dsp_comm/fec_conv.py
@@ -59,8 +59,9 @@ from logging import getLogger
 log = getLogger(__name__)
 import warnings
 
+
 # Data structure support classes
-class trellis_nodes(object):
+class TrellisNodes(object):
     """
     A structure to hold the trellis from nodes and to nodes.
     Ns is the number of states = :math:`2^{(K-1)}`.
@@ -71,7 +72,8 @@ class trellis_nodes(object):
         self.tn = np.zeros((Ns,1),dtype=int)
         self.out_bits = np.zeros((Ns,1),dtype=int)
 
-class trellis_branches(object):
+
+class TrellisBranches(object):
     """
     A structure to hold the trellis states, bits, and input values
     for both '1' and '0' transitions.
@@ -86,7 +88,8 @@ class trellis_branches(object):
         self.input1 = np.zeros((Ns,1),dtype=int)
         self.input2 = np.zeros((Ns,1),dtype=int)
 
-class trellis_paths(object):
+
+class TrellisPaths(object):
     """
     A structure to hold the trellis paths in terms of traceback_states,
     cumulative_metrics, and traceback_bits. A full decision depth history
@@ -103,13 +106,15 @@ class trellis_paths(object):
         self.cumulative_metric = np.zeros((Ns,self.decision_depth),dtype=float)
         self.traceback_bits = np.zeros((Ns,self.decision_depth),dtype=int)
 
+
 def binary(num, length=8):
         """
         Format an integer to binary without the leading '0b'
         """
         return format(num, '0{}b'.format(length))
 
-class fec_conv(object):
+
+class FecConv(object):
     """
     Class responsible for creating rate 1/2 convolutional code objects, and 
     then encoding and decoding the user code set in polynomials of G. Key
@@ -129,11 +134,11 @@ class fec_conv(object):
     --------
     >>> from sk_dsp_comm import fec_conv
     >>> # Rate 1/2
-    >>> cc1 = fec_conv.fec_conv(('101', '111'), Depth=10)  # decision depth is 10
+    >>> cc1 = fec_conv.FecConv(('101', '111'), Depth=10)  # decision depth is 10
 
     >>> # Rate 1/3
     >>> from sk_dsp_comm import fec_conv
-    >>> cc2 = fec_conv.fec_conv(('101','011','111'), Depth=15)  # decision depth is 15
+    >>> cc2 = fec_conv.FecConv(('101','011','111'), Depth=15)  # decision depth is 15
 
     
     """
@@ -188,9 +193,9 @@ class fec_conv(object):
         self.constraint_length = len(self.G_polys[0]) 
         self.Nstates = 2**(self.constraint_length-1) # number of states
         self.decision_depth = Depth
-        self.input_zero = trellis_nodes(self.Nstates)
-        self.input_one = trellis_nodes(self.Nstates)
-        self.paths = trellis_paths(self.Nstates,self.decision_depth)
+        self.input_zero = TrellisNodes(self.Nstates)
+        self.input_one = TrellisNodes(self.Nstates)
+        self.paths = TrellisPaths(self.Nstates, self.decision_depth)
         self.rate = Fraction(1,len(G))
         
         if(len(G) == 2 or len(G) == 3):
@@ -221,7 +226,7 @@ class fec_conv(object):
         # from state, the u2 u1 bit sequence in decimal form, and the input bit.
         # The index where this information is stored is the to state where survivors
         # are chosen from the two input branches.
-        self.branches = trellis_branches(self.Nstates)
+        self.branches = TrellisBranches(self.Nstates)
 
         for m in range(self.Nstates):
             match_zero_idx = np.where(self.input_zero.tn == m)
@@ -279,7 +284,7 @@ class fec_conv(object):
         >>> EbN0 = 4
         >>> total_bit_errors = 0
         >>> total_bit_count = 0
-        >>> cc1 = fec.fec_conv(('11101','10011'),25)
+        >>> cc1 = fec.FecConv(('11101','10011'),25)
         >>> # Encode with shift register starting state of '0000'
         >>> state = '0000'
         >>> while total_bit_errors < 100:
@@ -354,7 +359,7 @@ class fec_conv(object):
         >>> EbN0 = 3
         >>> total_bit_errors = 0
         >>> total_bit_count = 0
-        >>> cc2 = fec.fec_conv(('11111','11011','10101'),25)
+        >>> cc2 = fec.FecConv(('11111','11011','10101'),25)
         >>> # Encode with shift register starting state of '0000'
         >>> state = '0000'
         >>> while total_bit_errors < 100:
@@ -575,8 +580,8 @@ class fec_conv(object):
         the  :math:`G_{2}`  polynomial.
 
         >>> import numpy as np
-        >>> from sk_dsp_comm.fec_conv import fec_conv
-        >>> cc = fec_conv(('101','111'))
+        >>> from sk_dsp_comm.fec_conv import FecConv
+        >>> cc = FecConv(('101','111'))
         >>> x = np.array([0, 0, 1, 1, 1, 0, 0, 0, 0, 0])
         >>> state = '00'
         >>> y, state = cc.conv_encoder(x, state)
@@ -646,8 +651,8 @@ class fec_conv(object):
         the  :math:`G_{2}`  polynomial.
 
         >>> import numpy as np
-        >>> from sk_dsp_comm.fec_conv import fec_conv
-        >>> cc = fec_conv(('101','111'))
+        >>> from sk_dsp_comm.fec_conv import FecConv
+        >>> cc = FecConv(('101','111'))
         >>> x = np.array([0, 0, 1, 1, 1, 0, 0, 0, 0, 0])
         >>> state = '00'
         >>> y, state = cc.conv_encoder(x, state)
@@ -717,8 +722,8 @@ class fec_conv(object):
         Examples
         --------
         >>> import matplotlib.pyplot as plt
-        >>> from sk_dsp_comm.fec_conv import fec_conv
-        >>> cc = fec_conv()
+        >>> from sk_dsp_comm.fec_conv import FecConv
+        >>> cc = FecConv()
         >>> cc.trellis_plot()
         >>> plt.show()
         """
@@ -758,10 +763,10 @@ class fec_conv(object):
         Examples
         --------
         >>> import matplotlib.pyplot as plt
-        >>> from sk_dsp_comm.fec_conv import fec_conv
+        >>> from sk_dsp_comm.fec_conv import FecConv
         >>> from sk_dsp_comm import digitalcom as dc
         >>> import numpy as np
-        >>> cc = fec_conv()
+        >>> cc = FecConv()
         >>> x = np.random.randint(0,2,100)
         >>> state = '00'
         >>> y,state = cc.conv_encoder(x,state)
@@ -905,7 +910,7 @@ if __name__ == '__main__':
          0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 1,
          1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0, 1,
          0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1]
-    cc1 = fec_conv()
+    cc1 = FecConv()
     output, states = cc1.conv_encoder(x,'00')
     y = cc1.viterbi_decoder(7*output,'three_bit')
     

--- a/sk_dsp_comm/fec_conv.py
+++ b/sk_dsp_comm/fec_conv.py
@@ -54,7 +54,7 @@ from math import factorial
 from fractions import Fraction
 import matplotlib.pyplot as plt
 import warnings
-from .digitalcom import Q_fctn
+from .digitalcom import q_fctn
 from logging import getLogger
 log = getLogger(__name__)
 import warnings
@@ -844,7 +844,7 @@ def conv_Pb_bound(R,dfree,Ck,SNRdB,hard_soft,M=2):
                 Pb[n] += Ck[k-dfree]*soft_Pk(k,R,SNRn,M)
             else: # Compute Uncoded Pe
                 if M == 2:
-                    Pb[n] = Q_fctn(np.sqrt(2.*SNRn))
+                    Pb[n] = q_fctn(np.sqrt(2. * SNRn))
                 else:
                     Pb[n] = 4./np.log2(M)*(1 - 1/np.sqrt(M))*\
                             np.gaussQ(np.sqrt(3*np.log2(M)/(M-1)*SNRn));
@@ -862,10 +862,10 @@ def hard_Pk(k,R,SNR,M=2):
     k = int(k)
 
     if M == 2:
-        p = Q_fctn(np.sqrt(2.*R*SNR))
+        p = q_fctn(np.sqrt(2. * R * SNR))
     else:
-        p = 4./np.log2(M)*(1 - 1./np.sqrt(M))*\
-            Q_fctn(np.sqrt(3*R*np.log2(M)/float(M-1)*SNR))
+        p = 4. / np.log2(M) * (1 - 1./np.sqrt(M)) * \
+            q_fctn(np.sqrt(3 * R * np.log2(M) / float(M - 1) * SNR))
     Pk = 0
     #if 2*k//2 == k:
     if np.mod(k,2) == 0:
@@ -889,10 +889,10 @@ def soft_Pk(k,R,SNR,M=2):
     Mark Wickert November 2014
     """
     if M == 2:
-        Pk = Q_fctn(np.sqrt(2.*k*R*SNR))
+        Pk = q_fctn(np.sqrt(2. * k * R * SNR))
     else:
-        Pk = 4./np.log2(M)*(1 - 1./np.sqrt(M))*\
-             Q_fctn(np.sqrt(3*k*R*np.log2(M)/float(M-1)*SNR))
+        Pk = 4. / np.log2(M) * (1 - 1./np.sqrt(M)) * \
+             q_fctn(np.sqrt(3 * k * R * np.log2(M) / float(M - 1) * SNR))
     
     return Pk
 

--- a/sk_dsp_comm/fec_conv.py
+++ b/sk_dsp_comm/fec_conv.py
@@ -292,7 +292,7 @@ class FecConv(object):
         >>>     x = randint(0,2,N_bits_per_frame)
         >>>     y,state = cc1.conv_encoder(x,state)
         >>>     # Add channel noise to bits, include antipodal level shift to [-1,1]
-        >>>     yn_soft = dc.cpx_AWGN(2*y-1,EbN0-3,1) # Channel SNR is 3 dB less for rate 1/2
+        >>>     yn_soft = dc.cpx_awgn(2*y-1,EbN0-3,1) # Channel SNR is 3 dB less for rate 1/2
         >>>     yn_hard = ((np.sign(yn_soft.real)+1)/2).astype(int)
         >>>     z = cc1.viterbi_decoder(yn_hard,'hard')
         >>>     # Count bit errors
@@ -367,7 +367,7 @@ class FecConv(object):
         >>>     x = randint(0,2,N_bits_per_frame)
         >>>     y,state = cc2.conv_encoder(x,state)
         >>>     # Add channel noise to bits, include antipodal level shift to [-1,1]
-        >>>     yn_soft = dc.cpx_AWGN(2*y-1,EbN0-10*np.log10(3),1) # Channel SNR is 10*log10(3) dB less
+        >>>     yn_soft = dc.cpx_awgn(2*y-1,EbN0-10*np.log10(3),1) # Channel SNR is 10*log10(3) dB less
         >>>     yn_hard = ((np.sign(yn_soft.real)+1)/2).astype(int)
         >>>     z = cc2.viterbi_decoder(yn_hard.real,'hard')
         >>>     # Count bit errors
@@ -771,7 +771,7 @@ class FecConv(object):
         >>> state = '00'
         >>> y,state = cc.conv_encoder(x,state)
         >>> # Add channel noise to bits translated to +1/-1
-        >>> yn = dc.cpx_AWGN(2*y-1,5,1) # SNR = 5 dB
+        >>> yn = dc.cpx_awgn(2*y-1,5,1) # SNR = 5 dB
         >>> # Translate noisy +1/-1 bits to soft values on [0,7]
         >>> yn = (yn.real+1)/2*7
         >>> z = cc.viterbi_decoder(yn)

--- a/sk_dsp_comm/fir_design_helper.py
+++ b/sk_dsp_comm/fir_design_helper.py
@@ -36,7 +36,7 @@ from logging import getLogger
 log = getLogger(__name__)
 
 
-def firwin_lpf(N_taps, fc, fs = 1.0):
+def firwin_lpf(n_taps, fc, fs = 1.0):
     """
     Design a windowed FIR lowpass filter in terms of passband
     critical frequencies f1 < f2 in Hz relative to sampling rate
@@ -44,10 +44,10 @@ def firwin_lpf(N_taps, fc, fs = 1.0):
     
     Mark Wickert October 2016
     """
-    return signal.firwin(N_taps,2*fc/fs)
+    return signal.firwin(n_taps, 2 * fc / fs)
 
 
-def firwin_bpf(N_taps, f1, f2, fs = 1.0, pass_zero=False):
+def firwin_bpf(n_taps, f1, f2, fs = 1.0, pass_zero=False):
     """
     Design a windowed FIR bandpass filter in terms of passband
     critical frequencies f1 < f2 in Hz relative to sampling rate
@@ -55,10 +55,10 @@ def firwin_bpf(N_taps, f1, f2, fs = 1.0, pass_zero=False):
 
     Mark Wickert October 2016
     """
-    return signal.firwin(N_taps,2*(f1,f2)/fs,pass_zero=pass_zero)
+    return signal.firwin(n_taps, 2 * (f1, f2) / fs, pass_zero=pass_zero)
 
 
-def firwin_kaiser_lpf(f_pass, f_stop, d_stop, fs = 1.0, N_bump=0, status = True):
+def firwin_kaiser_lpf(f_pass, f_stop, d_stop, fs = 1.0, n_bump=0, status = True):
     """
     Design an FIR lowpass filter using the sinc() kernel and
     a Kaiser window. The filter order is determined based on 
@@ -74,7 +74,7 @@ def firwin_kaiser_lpf(f_pass, f_stop, d_stop, fs = 1.0, N_bump=0, status = True)
     # Find the filter order
     M = np.ceil((d_stop - 8)/(2.285*delta_w))
     # Adjust filter order up or down as needed
-    M += N_bump
+    M += n_bump
     N_taps = M + 1
     # Obtain the Kaiser window
     beta = signal.kaiser_beta(d_stop)
@@ -87,7 +87,7 @@ def firwin_kaiser_lpf(f_pass, f_stop, d_stop, fs = 1.0, N_bump=0, status = True)
     return b_k
 
 
-def firwin_kaiser_hpf(f_stop, f_pass, d_stop, fs = 1.0, N_bump=0, status = True):
+def firwin_kaiser_hpf(f_stop, f_pass, d_stop, fs = 1.0, n_bump=0, status = True):
     """
     Design an FIR highpass filter using the sinc() kernel and
     a Kaiser window. The filter order is determined based on 
@@ -107,7 +107,7 @@ def firwin_kaiser_hpf(f_stop, f_pass, d_stop, fs = 1.0, N_bump=0, status = True)
     # Find the filter order
     M = np.ceil((d_stop - 8)/(2.285*delta_w))
     # Adjust filter order up or down as needed
-    M += N_bump
+    M += n_bump
     N_taps = M + 1
     # Obtain the Kaiser window
     beta = signal.kaiser_beta(d_stop)
@@ -123,8 +123,8 @@ def firwin_kaiser_hpf(f_stop, f_pass, d_stop, fs = 1.0, N_bump=0, status = True)
     return b_k
 
 
-def firwin_kaiser_bpf(f_stop1, f_pass1, f_pass2, f_stop2, d_stop, 
-                      fs = 1.0, N_bump=0, status = True):
+def firwin_kaiser_bpf(f_stop1, f_pass1, f_pass2, f_stop2, d_stop,
+                      fs = 1.0, n_bump=0, status = True):
     """
     Design an FIR bandpass filter using the sinc() kernel and
     a Kaiser window. The filter order is determined based on 
@@ -148,7 +148,7 @@ def firwin_kaiser_bpf(f_stop1, f_pass1, f_pass2, f_stop2, d_stop,
     # Find the filter order
     M = np.ceil((d_stop - 8)/(2.285*delta_w))
     # Adjust filter order up or down as needed
-    M += N_bump
+    M += n_bump
     N_taps = M + 1
     # Obtain the Kaiser window
     beta = signal.kaiser_beta(d_stop)
@@ -166,8 +166,8 @@ def firwin_kaiser_bpf(f_stop1, f_pass1, f_pass2, f_stop2, d_stop,
     return b_k_bp
 
 
-def firwin_kaiser_bsf(f_stop1, f_pass1, f_pass2, f_stop2, d_stop, 
-                  fs = 1.0, N_bump=0, status = True):
+def firwin_kaiser_bsf(f_stop1, f_pass1, f_pass2, f_stop2, d_stop,
+                      fs = 1.0, n_bump=0, status = True):
     """
     Design an FIR bandstop filter using the sinc() kernel and
     a Kaiser window. The filter order is determined based on 
@@ -193,7 +193,7 @@ def firwin_kaiser_bsf(f_stop1, f_pass1, f_pass2, f_stop2, d_stop,
     # Find the filter order
     M = np.ceil((d_stop - 8)/(2.285*delta_w))
     # Adjust filter order up or down as needed
-    M += N_bump
+    M += n_bump
     # Make filter order even (odd number of taps)
     if ((M+1)/2.0-int((M+1)/2.0)) == 0:
         M += 1
@@ -311,7 +311,7 @@ def bandstop_order(f_stop1, f_pass1, f_pass2, f_stop2, dpass_dB, dstop_dB, fsamp
     return int(N), ff, aa, wts
 
 
-def fir_remez_lpf(f_pass, f_stop, d_pass, d_stop, fs = 1.0, N_bump=5, status = True):
+def fir_remez_lpf(f_pass, f_stop, d_pass, d_stop, fs = 1.0, n_bump=5, status = True):
     """
     Design an FIR lowpass filter using remez with order
     determination. The filter order is determined based on 
@@ -324,14 +324,14 @@ def fir_remez_lpf(f_pass, f_stop, d_pass, d_stop, fs = 1.0, N_bump=5, status = T
     n, ff, aa, wts = lowpass_order(f_pass, f_stop, d_pass, d_stop, fsamp=fs)
     # Bump up the order by N_bump to bring down the final d_pass & d_stop
     N_taps = n
-    N_taps += N_bump
+    N_taps += n_bump
     b = signal.remez(N_taps, ff, aa[0::2], wts,Hz=2)
     if status:
         log.info('Remez filter taps = %d.' % N_taps)
     return b
 
 
-def fir_remez_hpf(f_stop, f_pass, d_pass, d_stop, fs = 1.0, N_bump=5, status = True):
+def fir_remez_hpf(f_stop, f_pass, d_pass, d_stop, fs = 1.0, n_bump=5, status = True):
     """
     Design an FIR highpass filter using remez with order
     determination. The filter order is determined based on 
@@ -348,7 +348,7 @@ def fir_remez_hpf(f_stop, f_pass, d_pass, d_stop, fs = 1.0, N_bump=5, status = T
     n, ff, aa, wts = lowpass_order(f_pass_eq, f_stop_eq, d_pass, d_stop, fsamp=fs)
     # Bump up the order by N_bump to bring down the final d_pass & d_stop
     N_taps = n
-    N_taps += N_bump
+    N_taps += n_bump
     b = signal.remez(N_taps, ff, aa[0::2], wts,Hz=2)
     # Transform LPF equivalent to HPF
     n = np.arange(len(b))
@@ -358,8 +358,8 @@ def fir_remez_hpf(f_stop, f_pass, d_pass, d_stop, fs = 1.0, N_bump=5, status = T
     return b
 
 
-def fir_remez_bpf(f_stop1, f_pass1, f_pass2, f_stop2, d_pass, d_stop, 
-                  fs = 1.0, N_bump=5, status = True):
+def fir_remez_bpf(f_stop1, f_pass1, f_pass2, f_stop2, d_pass, d_stop,
+                  fs = 1.0, n_bump=5, status = True):
     """
     Design an FIR bandpass filter using remez with order
     determination. The filter order is determined based on 
@@ -373,15 +373,15 @@ def fir_remez_bpf(f_stop1, f_pass1, f_pass2, f_stop2, d_pass, d_stop,
                                   d_pass, d_stop, fsamp=fs)
     # Bump up the order by N_bump to bring down the final d_pass & d_stop
     N_taps = n
-    N_taps += N_bump
+    N_taps += n_bump
     b = signal.remez(N_taps, ff, aa[0::2], wts,Hz=2)
     if status:
         log.info('Remez filter taps = %d.' % N_taps)
     return b
 
 
-def fir_remez_bsf(f_pass1, f_stop1, f_stop2, f_pass2, d_pass, d_stop, 
-                  fs = 1.0, N_bump=5, status = True):
+def fir_remez_bsf(f_pass1, f_stop1, f_stop2, f_pass2, d_pass, d_stop,
+                  fs = 1.0, n_bump=5, status = True):
     """
     Design an FIR bandstop filter using remez with order
     determination. The filter order is determined based on 
@@ -398,7 +398,7 @@ def fir_remez_bsf(f_pass1, f_stop1, f_stop2, f_pass2, d_pass, d_stop,
     if np.mod(n,2) != 0:
         n += 1
     N_taps = n
-    N_taps += N_bump
+    N_taps += n_bump
     b = signal.remez(N_taps, ff, aa[0::2], wts, Hz=2,
                      maxiter = 25, grid_density = 16)
     if status:
@@ -407,7 +407,7 @@ def fir_remez_bsf(f_pass1, f_stop1, f_stop2, f_pass2, d_pass, d_stop,
     return b
 
 
-def freqz_resp_list(b,a=np.array([1]),mode = 'dB',fs=1.0,Npts = 1024,fsize=(6,4)):
+def freqz_resp_list(b, a=np.array([1]), mode = 'dB', fs=1.0, n_pts = 1024, fsize=(6, 4)):
     """
     A method for displaying digital filter frequency response magnitude,
     phase, and group delay. A plot is produced using matplotlib
@@ -432,7 +432,7 @@ def freqz_resp_list(b,a=np.array([1]),mode = 'dB',fs=1.0,Npts = 1024,fsize=(6,4)
     if type(b) == list:
         # We have a list of filters
         N_filt = len(b)
-    f = np.arange(0,Npts)/(2.0*Npts)
+    f = np.arange(0, n_pts) / (2.0 * n_pts)
     for n in range(N_filt):
         w,H = signal.freqz(b[n],a[n],2*np.pi*f)
         if n == 0:

--- a/sk_dsp_comm/iir_design_helper.py
+++ b/sk_dsp_comm/iir_design_helper.py
@@ -316,7 +316,7 @@ def freqz_cas(sos,w):
     return w, Hcas
 
 
-def freqz_resp_cas_list(sos,mode = 'dB',fs=1.0,Npts = 1024,fsize=(6,4)):
+def freqz_resp_cas_list(sos, mode = 'dB', fs=1.0, n_pts=1024, fsize=(6, 4)):
     """
     A method for displaying cascade digital filter form frequency response 
     magnitude, phase, and group delay. A plot is produced using matplotlib
@@ -341,7 +341,7 @@ def freqz_resp_cas_list(sos,mode = 'dB',fs=1.0,Npts = 1024,fsize=(6,4)):
     if type(sos) == list:
         # We have a list of filters
         N_filt = len(sos)
-    f = np.arange(0,Npts)/(2.0*Npts)
+    f = np.arange(0, n_pts) / (2.0 * n_pts)
     for n in range(N_filt):
         w,H = freqz_cas(sos[n],2*np.pi*f)
         if n == 0:

--- a/sk_dsp_comm/multirate_helper.py
+++ b/sk_dsp_comm/multirate_helper.py
@@ -131,7 +131,7 @@ class multirate_FIR(object):
         """
 
         """
-        fir_d.freqz_resp_list([self.b],[1], mode, fs=fs, Npts = 1024)
+        fir_d.freqz_resp_list([self.b], [1], mode, fs=fs, n_pts= 1024)
         pylab.grid()
         pylab.ylim(ylim)
 

--- a/sk_dsp_comm/sigsys.py
+++ b/sk_dsp_comm/sigsys.py
@@ -1005,7 +1005,7 @@ def fir_iir_notch(fi,fs,r=0.95):
     return b, a
 
 
-def simple_SA(x,NS,NFFT,fs,NAVG=1,window='boxcar'):
+def simple_sa(x, NS, NFFT, fs, NAVG=1, window='boxcar'):
     """
     Spectral estimation using windowing and averaging.
 
@@ -1039,7 +1039,7 @@ def simple_SA(x,NS,NFFT,fs,NAVG=1,window='boxcar'):
     >>> from sk_dsp_comm import sigsys as ss
     >>> n = np.arange(0,2048)
     >>> x = np.cos(2*np.pi*1000/10000*n) + 0.01*np.cos(2*np.pi*3000/10000*n)
-    >>> f, Sx = ss.simple_SA(x,128,512,10000)
+    >>> f, Sx = ss.simple_sa(x,128,512,10000)
     >>> plt.plot(f, 10*np.log10(Sx))
     >>> plt.ylim([-80, 0])
     >>> plt.xlabel("Frequency (Hz)")
@@ -1048,7 +1048,7 @@ def simple_SA(x,NS,NFFT,fs,NAVG=1,window='boxcar'):
 
     With a hanning window.
 
-    >>> f, Sx = ss.simple_SA(x,256,1024,10000,window='hanning')
+    >>> f, Sx = ss.simple_sa(x,256,1024,10000,window='hanning')
     >>> plt.plot(f, 10*np.log10(Sx))
     >>> plt.xlabel("Frequency (Hz)")
     >>> plt.ylabel("Power Spectral Density (dB)")
@@ -1087,7 +1087,7 @@ def simple_SA(x,NS,NFFT,fs,NAVG=1,window='boxcar'):
 
 def line_spectra(fk,Xk,mode,sides=2,linetype='b',lwidth=2,floor_dB=-100,fsize=(6,4)):
     """
-    Plot the Fouier series line spectral given the coefficients.
+    Plot the Fourier series line spectral given the coefficients.
 
     This function plots two-sided and one-sided line spectra of a periodic
     signal given the complex exponential Fourier series coefficients and

--- a/sk_dsp_comm/sigsys.py
+++ b/sk_dsp_comm/sigsys.py
@@ -693,7 +693,7 @@ def lp_tri(f, fb):
     return x
 
 
-def sinusoid_AWGN(x, SNRdB):
+def sinusoid_awgn(x, SNRdB):
     """
     Add white Gaussian noise to a single real sinusoid.
     
@@ -715,7 +715,7 @@ def sinusoid_AWGN(x, SNRdB):
     >>> # set the SNR to 10 dB
     >>> n = arange(0,10000)
     >>> x = cos(2*pi*0.04*n)
-    >>> y = sinusoid_AWGN(x,10.0)
+    >>> y = sinusoid_awgn(x,10.0)
     """
     # Estimate signal power
     x_pwr = np.var(x)
@@ -756,7 +756,7 @@ def simple_quant(x, b_tot, x_max, limit):
     >>> from sk_dsp_comm import sigsys as ss
     >>> n = np.arange(0,10000)
     >>> x = np.cos(2*np.pi*0.211*n)
-    >>> y = ss.sinusoid_AWGN(x,90)
+    >>> y = ss.sinusoid_awgn(x,90)
     >>> Px, f = psd(y,2**10,Fs=1)
     >>> plt.plot(f, 10*np.log10(Px))
     >>> plt.ylim([-80, 25])

--- a/sk_dsp_comm/sigsys.py
+++ b/sk_dsp_comm/sigsys.py
@@ -540,7 +540,7 @@ def os_filter(x, h, N, mode=0):
         return y[P-1:Nx]
 
 
-def OA_filter(x,h,N,mode=0):
+def oa_filter(x, h, N, mode=0):
     """
     Overlap and add transform domain FIR filtering.
     
@@ -566,13 +566,13 @@ def OA_filter(x,h,N,mode=0):
     Examples
     --------
     >>> import numpy as np
-    >>> from sk_dsp_comm.sigsys import OA_filter
+    >>> from sk_dsp_comm.sigsys import oa_filter
     >>> n = np.arange(0,100)
-    >>> x = np.cos(2*pi*0.05*n)
+    >>> x = np.cos(2*np.pi*0.05*n)
     >>> b = np.ones(10)
-    >>> y = OA_filter(x,h,N)
+    >>> y = oa_filter(x,h,N)
     >>> # set mode = 1
-    >>> y, y_mat = OA_filter(x,h,N,1)
+    >>> y, y_mat = oa_filter(x,h,N,1)
     """
     P = len(h)
     L = int(N) - P + 1 # need N >= L + P -1

--- a/sk_dsp_comm/sigsys.py
+++ b/sk_dsp_comm/sigsys.py
@@ -479,7 +479,7 @@ def splane(b,a,auto_scale=True,size=[-1,1,-1,1]):
     return M,N
 
 
-def OS_filter(x,h,N,mode=0):
+def os_filter(x, h, N, mode=0):
     """
     Overlap and save transform domain FIR filtering.
     
@@ -504,12 +504,13 @@ def OS_filter(x,h,N,mode=0):
     
     Examples
     --------
+    >>> from numpy import arange, cos, pi, ones
     >>> n = arange(0,100)
     >>> x = cos(2*pi*0.05*n)
     >>> b = ones(10)
-    >>> y = OS_filter(x,h,N)
+    >>> y = os_filter(x,h,N)
     >>> # set mode = 1
-    >>> y, y_mat = OS_filter(x,h,N,1)
+    >>> y, y_mat = os_filter(x,h,N,1)
     """
     
     P = len(h)

--- a/sk_dsp_comm/sigsys.py
+++ b/sk_dsp_comm/sigsys.py
@@ -59,7 +59,7 @@ log = getLogger(__name__)
 import warnings
 
 
-def CIC(m, k):
+def cic(m, k):
     """
     A functional form implementation of a cascade of integrator comb (CIC) filters.
 
@@ -91,6 +91,7 @@ def CIC(m, k):
 
     # Make filter have unity gain at DC
     return b / np.sum(b)
+
 
 def ten_band_eq_filt(x,GdB,Q=3.5):
     """
@@ -282,7 +283,7 @@ def ex6_2(n):
     return x
 
 
-def position_CD(Ka,out_type = 'fb_exact'):
+def position_cd(Ka, out_type ='fb_exact'):
     """
     CD sled position control case study of Chapter 18.
 
@@ -311,8 +312,8 @@ def position_CD(Ka,out_type = 'fb_exact'):
 
     Examples
     --------
-    >>> b,a = position_CD(Ka,'fb_approx')
-    >>> b,a = position_CD(Ka,'fb_exact')
+    >>> b,a = position_cd(Ka,'fb_approx')
+    >>> b,a = position_cd(Ka,'fb_exact')
     """
     rs = 10/(2*np.pi)
     # Load b and a ndarrays with the coefficients

--- a/sk_dsp_comm/sigsys.py
+++ b/sk_dsp_comm/sigsys.py
@@ -59,14 +59,14 @@ log = getLogger(__name__)
 import warnings
 
 
-def CIC(M, K):
+def CIC(m, k):
     """
     A functional form implementation of a cascade of integrator comb (CIC) filters.
 
     Parameters
     ----------
-    M : Effective number of taps per section (typically the decimation factor).
-    K : The number of CIC sections cascaded (larger K gives the filter a wider image rejection bandwidth).
+    m : Effective number of taps per section (typically the decimation factor).
+    k : The number of CIC sections cascaded (larger K gives the filter a wider image rejection bandwidth).
 
     Returns
     -------
@@ -81,12 +81,12 @@ def CIC(M, K):
     Mark Wickert July 2013
     """
 
-    if K == 1:
-        b = np.ones(M)
+    if k == 1:
+        b = np.ones(m)
     else:
-        h = np.ones(M)
+        h = np.ones(m)
         b = h
-        for i in range(1, K):
+        for i in range(1, k):
             b = signal.convolve(b, h)  # cascade by convolving impulse responses
 
     # Make filter have unity gain at DC
@@ -691,7 +691,7 @@ def lp_tri(f, fb):
     return x
 
 
-def sinusoidAWGN(x,SNRdB):
+def sinusoid_AWGN(x, SNRdB):
     """
     Add white Gaussian noise to a single real sinusoid.
     
@@ -713,7 +713,7 @@ def sinusoidAWGN(x,SNRdB):
     >>> # set the SNR to 10 dB
     >>> n = arange(0,10000)
     >>> x = cos(2*pi*0.04*n)
-    >>> y = sinusoidAWGN(x,10.0)
+    >>> y = sinusoid_AWGN(x,10.0)
     """
     # Estimate signal power
     x_pwr = np.var(x)
@@ -723,7 +723,7 @@ def sinusoidAWGN(x,SNRdB):
     return x + noise
 
 
-def simpleQuant(x,Btot,Xmax,Limit):
+def simple_quant(x, b_tot, x_max, limit):
     """
     A simple rounding quantizer for bipolar signals having Btot = B + 1 bits.
     
@@ -734,8 +734,8 @@ def simpleQuant(x,Btot,Xmax,Limit):
     Parameters
     ----------
     x : input signal ndarray to be quantized
-    Btot : total number of bits in the quantizer, e.g. 16
-    Xmax : quantizer full-scale dynamic range is [-Xmax, Xmax]
+    b_tot : total number of bits in the quantizer, e.g. 16
+    x_max : quantizer full-scale dynamic range is [-Xmax, Xmax]
     Limit = Limiting of the form 'sat', 'over', 'none'
     
     Returns
@@ -754,7 +754,7 @@ def simpleQuant(x,Btot,Xmax,Limit):
     >>> from sk_dsp_comm import sigsys as ss
     >>> n = np.arange(0,10000)
     >>> x = np.cos(2*np.pi*0.211*n)
-    >>> y = ss.sinusoidAWGN(x,90)
+    >>> y = ss.sinusoid_AWGN(x,90)
     >>> Px, f = psd(y,2**10,Fs=1)
     >>> plt.plot(f, 10*np.log10(Px))
     >>> plt.ylim([-80, 25])
@@ -762,7 +762,7 @@ def simpleQuant(x,Btot,Xmax,Limit):
     >>> plt.xlabel(r'Normalized Frequency $\omega/2\pi$')
     >>> plt.show()
 
-    >>> yq = ss.simpleQuant(y,12,1,'sat')
+    >>> yq = ss.simple_quant(y,12,1,'sat')
     >>> Px, f = psd(yq,2**10,Fs=1)
     >>> plt.plot(f, 10*np.log10(Px))
     >>> plt.ylim([-80, 25])
@@ -770,22 +770,22 @@ def simpleQuant(x,Btot,Xmax,Limit):
     >>> plt.xlabel(r'Normalized Frequency $\omega/2\pi$')
     >>> plt.show()
     """
-    B = Btot-1
-    x = x/Xmax
-    if Limit.lower() == 'over':
-        xq = (np.mod(np.round(x*2**B)+2**B,2**Btot)-2**B)/2**B
-    elif Limit.lower() == 'sat':
+    B = b_tot - 1
+    x = x / x_max
+    if limit.lower() == 'over':
+        xq = (np.mod(np.round(x*2**B) + 2 ** B, 2 ** b_tot) - 2 ** B) / 2 ** B
+    elif limit.lower() == 'sat':
         xq = np.round(x*2**B)+2**B
-        s1 = np.nonzero(np.ravel(xq >= 2**Btot-1))[0]
+        s1 = np.nonzero(np.ravel(xq >= 2 ** b_tot - 1))[0]
         s2 = np.nonzero(np.ravel(xq < 0))[0]
-        xq[s1] = (2**Btot - 1)*np.ones(len(s1))
+        xq[s1] = (2 ** b_tot - 1) * np.ones(len(s1))
         xq[s2] = np.zeros(len(s2))
         xq = (xq - 2**B)/2**B
-    elif Limit.lower() == 'none':
+    elif limit.lower() == 'none':
         xq = np.round(x*2**B)/2**B
     else:
         raise ValueError('limit must be the string over, sat, or none')
-    return xq*Xmax
+    return xq * x_max
 
 
 def prin_alias(f_in,fs):
@@ -1943,7 +1943,7 @@ def sqrt_rc_imp(Ns,alpha,M=6):
     return b
 
 
-def PN_gen(N_bits,m=5):
+def pn_gen(n_bits, m=5):
     """
     Maximal length sequence signal generator.
 
@@ -1953,7 +1953,7 @@ def PN_gen(N_bits,m=5):
             
     Parameters
     ----------
-    N_bits : the number of bits to generate
+    n_bits : the number of bits to generate
     m : the number of shift registers. 2,3, .., 12, & 16
 
     Returns
@@ -1967,15 +1967,15 @@ def PN_gen(N_bits,m=5):
     Examples
     --------
     >>> # A 15 bit period signal nover 50 bits
-    >>> PN = PN_gen(50,4)
+    >>> PN = pn_gen(50,4)
     """
     c = m_seq(m)
     Q = len(c)
-    max_periods = int(np.ceil(N_bits/float(Q)))
+    max_periods = int(np.ceil(n_bits / float(Q)))
     PN = np.zeros(max_periods*Q)
     for k in range(max_periods):
         PN[k*Q:(k+1)*Q] = c
-    PN = np.resize(PN, (1,N_bits))
+    PN = np.resize(PN, (1, n_bits))
     return PN.flatten()
 
 
@@ -2043,7 +2043,7 @@ def m_seq(m):
     return c
 
 
-def BPSK_tx(N_bits,Ns,ach_fc=2.0,ach_lvl_dB=-100,pulse='rect',alpha = 0.25,M=6):
+def bpsk_tx(N_bits, Ns, ach_fc=2.0, ach_lvl_dB=-100, pulse='rect', alpha = 0.25, M=6):
     """
     Generates biphase shift keyed (BPSK) transmitter with adjacent channel interference.
 
@@ -2074,14 +2074,14 @@ def BPSK_tx(N_bits,Ns,ach_fc=2.0,ach_lvl_dB=-100,pulse='rect',alpha = 0.25,M=6):
 
     Examples
     --------
-    >>> x,b,data0 = BPSK_tx(1000,10,pulse='src')
+    >>> x,b,data0 = bpsk_tx(1000,10,pulse='src')
     """
     pulse_types = ['rect', 'src']
     if pulse not in pulse_types:
         raise ValueError('Pulse shape must be \'rect\' or \'src\'''')
-    x0,b,data0 = NRZ_bits(N_bits,Ns,pulse,alpha,M)
-    x1p,b,data1p = NRZ_bits(N_bits,Ns,pulse,alpha,M)
-    x1m,b,data1m = NRZ_bits(N_bits,Ns,pulse,alpha,M)
+    x0,b,data0 = nrz_bits(N_bits, Ns, pulse, alpha, M)
+    x1p,b,data1p = nrz_bits(N_bits, Ns, pulse, alpha, M)
+    x1m,b,data1m = nrz_bits(N_bits, Ns, pulse, alpha, M)
     n = np.arange(len(x0))
     x1p = x1p*np.exp(1j*2*np.pi*ach_fc/float(Ns)*n)
     x1m = x1m*np.exp(-1j*2*np.pi*ach_fc/float(Ns)*n)
@@ -2089,7 +2089,7 @@ def BPSK_tx(N_bits,Ns,ach_fc=2.0,ach_lvl_dB=-100,pulse='rect',alpha = 0.25,M=6):
     return x0 + ach_lvl*(x1p + x1m), b, data0
 
 
-def NRZ_bits(N_bits,Ns,pulse='rect',alpha = 0.25,M=6):
+def nrz_bits(n_bits, ns, pulse='rect', alpha=0.25, m=6):
     """
     Generate non-return-to-zero (NRZ) data bits with pulse shaping.
 
@@ -2098,11 +2098,11 @@ def NRZ_bits(N_bits,Ns,pulse='rect',alpha = 0.25,M=6):
 
     Parameters
     ----------
-    N_bits : number of NRZ +/-1 data bits to produce
-    Ns : the number of samples per bit,
+    n_bits : number of NRZ +/-1 data bits to produce
+    ns : the number of samples per bit,
     pulse_type : 'rect' , 'rc', 'src' (default 'rect')
     alpha : excess bandwidth factor(default 0.25)
-    M : single sided pulse duration (default = 6) 
+    m : single sided pulse duration (default = 6)
 
     Returns
     -------
@@ -2119,31 +2119,31 @@ def NRZ_bits(N_bits,Ns,pulse='rect',alpha = 0.25,M=6):
     Examples
     --------
     >>> import matplotlib.pyplot as plt
-    >>> from sk_dsp_comm.sigsys import NRZ_bits
+    >>> from sk_dsp_comm.sigsys import nrz_bits
     >>> from numpy import arange
-    >>> x,b,data = NRZ_bits(100, 10)
+    >>> x,b,data = nrz_bits(100, 10)
     >>> t = arange(len(x))
     >>> plt.plot(t, x)
     >>> plt.ylim([-1.01, 1.01])
     >>> plt.show()
     """
-    data = np.random.randint(0,2,N_bits)
-    n_zeros = np.zeros((N_bits,int(Ns)-1))
-    x = np.hstack((2*data.reshape(N_bits,1)-1,n_zeros))
+    data = np.random.randint(0, 2, n_bits)
+    n_zeros = np.zeros((n_bits, int(ns) - 1))
+    x = np.hstack((2 * data.reshape(n_bits, 1) - 1, n_zeros))
     x =x.flatten()
     if pulse.lower() == 'rect':
-        b = np.ones(int(Ns))
+        b = np.ones(int(ns))
     elif pulse.lower() == 'rc':
-        b = rc_imp(Ns,alpha,M)
+        b = rc_imp(ns, alpha, m)
     elif pulse.lower() == 'src':
-        b = sqrt_rc_imp(Ns,alpha,M)
+        b = sqrt_rc_imp(ns, alpha, m)
     else:
         raise ValueError('pulse type must be rec, rc, or src')
     x = signal.lfilter(b,1,x)
-    return x,b/float(Ns),data
+    return x, b / float(ns), data
 
 
-def NRZ_bits2(data,Ns,pulse='rect',alpha = 0.25,M=6):
+def nrz_bits2(data, Ns, pulse='rect', alpha = 0.25, M=6):
     """
     Generate non-return-to-zero (NRZ) data bits with pulse shaping with user data
 
@@ -2171,10 +2171,10 @@ def NRZ_bits2(data,Ns,pulse='rect',alpha = 0.25,M=6):
     Examples
     --------
     >>> import matplotlib.pyplot as plt
-    >>> from sk_dsp_comm.sigsys import NRZ_bits2
+    >>> from sk_dsp_comm.sigsys import nrz_bits2
     >>> from sk_dsp_comm.sigsys import m_seq
     >>> from numpy import arange
-    >>> x,b = NRZ_bits2(m_seq(5),10)
+    >>> x,b = nrz_bits2(m_seq(5),10)
     >>> t = arange(len(x))
     >>> plt.ylim([-1.01, 1.01])
     >>> plt.plot(t,x)
@@ -2195,7 +2195,7 @@ def NRZ_bits2(data,Ns,pulse='rect',alpha = 0.25,M=6):
     return x,b/float(Ns)
 
 
-def eye_plot(x,L,S=0):
+def eye_plot(x, l, s=0):
     """
     Eye pattern plot of a baseband digital communications waveform.
 
@@ -2205,8 +2205,8 @@ def eye_plot(x,L,S=0):
     Parameters
     ----------
     x : ndarray of the real input data vector/array
-    L : display length in samples (usually two symbols)
-    S : start index
+    l : display length in samples (usually two symbols)
+    s : start index
 
     Returns
     -------
@@ -2222,15 +2222,15 @@ def eye_plot(x,L,S=0):
 
     >>> import matplotlib.pyplot as plt
     >>> from sk_dsp_comm import sigsys as ss
-    >>> x,b, data = ss.NRZ_bits(1000,10,'rc')
+    >>> x,b, data = ss.nrz_bits(1000,10,'rc')
     >>> ss.eye_plot(x,20,60)
     """
     plt.figure(figsize=(6,4))
-    idx = np.arange(0,L+1)
-    plt.plot(idx,x[S:S+L+1],'b')
-    k_max = int((len(x) - S)/L)-1
+    idx = np.arange(0, l + 1)
+    plt.plot(idx, x[s:s + l + 1], 'b')
+    k_max = int((len(x) - s) / l) - 1
     for k in range(1,k_max):
-         plt.plot(idx,x[S+k*L:S+L+1+k*L],'b')
+         plt.plot(idx, x[s + k * l:s + l + 1 + k * l], 'b')
     plt.grid()
     plt.xlabel('Time Index - n')
     plt.ylabel('Amplitude')
@@ -2238,14 +2238,14 @@ def eye_plot(x,L,S=0):
     return 0
 
 
-def scatter(x,Ns,start):
+def scatter(x, ns, start):
     """
     Sample a baseband digital communications waveform at the symbol spacing.
 
     Parameters
     ----------
     x : ndarray of the input digital comm signal
-    Ns : number of samples per symbol (bit)
+    ns : number of samples per symbol (bit)
     start : the array index to start the sampling
 
     Returns
@@ -2265,9 +2265,9 @@ def scatter(x,Ns,start):
     --------
     >>> import matplotlib.pyplot as plt
     >>> from sk_dsp_comm import sigsys as ss
-    >>> x,b, data = ss.NRZ_bits(1000,10,'rc')
+    >>> x,b, data = ss.nrz_bits(1000,10,'rc')
     >>> # Add some noise so points are now scattered about +/-1
-    >>> y = ss.cpx_AWGN(x,20,10)
+    >>> y = ss.cpx_awgn(x,20,10)
     >>> yI,yQ = ss.scatter(y,10,60)
     >>> plt.plot(yI,yQ,'.')
     >>> plt.axis('equal')
@@ -2276,12 +2276,12 @@ def scatter(x,Ns,start):
     >>> plt.grid()
     >>> plt.show()
     """
-    xI = np.real(x[start::Ns])
-    xQ = np.imag(x[start::Ns])
+    xI = np.real(x[start::ns])
+    xQ = np.imag(x[start::ns])
     return xI, xQ
 
 
-def bit_errors(z,data,start,Ns):
+def bit_errors(z, data, start, ns):
     """
     A simple bit error counting function.
     
@@ -2297,7 +2297,7 @@ def bit_errors(z,data,start,Ns):
     z : ndarray of hard decision BPSK data prior to symbol spaced sampling
     data : ndarray of reference bits in 1/0 format
     start : timing reference for the received
-    Ns : the number of samples per symbol
+    ns : the number of samples per symbol
 
     Returns
     -------
@@ -2313,19 +2313,19 @@ def bit_errors(z,data,start,Ns):
     Examples
     --------
     >>> from scipy import signal
-    >>> x,b, data = NRZ_bits(1000,10)
+    >>> x,b, data = nrz_bits(1000,10)
     >>> # set Eb/N0 to 8 dB
-    >>>  y = cpx_AWGN(x,8,10)
+    >>>  y = cpx_awgn(x,8,10)
     >>> # matched filter the signal
     >>> z = signal.lfilter(b,1,y)
     >>> # make bit decisions at 10 and Ns multiples thereafter
     >>> Pe_hat = bit_errors(z,data,10,10)
     """
-    Pe_hat = np.sum(data[0:len(z[start::Ns])]^np.int64((np.sign(np.real(z[start::Ns]))+1)/2))/float(len(z[start::Ns]))
+    Pe_hat = np.sum(data[0:len(z[start::ns])] ^ np.int64((np.sign(np.real(z[start::ns])) + 1) / 2)) / float(len(z[start::ns]))
     return Pe_hat
 
 
-def cpx_AWGN(x,EsN0,Ns):
+def cpx_awgn(x, es_n0, ns):
     """
     Apply white Gaussian noise to a digital communications signal.
 
@@ -2337,7 +2337,7 @@ def cpx_AWGN(x,EsN0,Ns):
     ----------
     x : ndarray noise free complex baseband input signal.
     EsNO : set the channel Es/N0 (Eb/N0 for binary) level in dB
-    Ns : number of samples per symbol (bit)
+    ns : number of samples per symbol (bit)
 
     Returns
     -------
@@ -2350,11 +2350,11 @@ def cpx_AWGN(x,EsN0,Ns):
 
     Examples
     --------
-    >>> x,b, data = NRZ_bits(1000,10)
+    >>> x,b, data = nrz_bits(1000,10)
     >>> # set Eb/N0 = 10 dB
-    >>> y = cpx_AWGN(x,10,10)
+    >>> y = cpx_awgn(x,10,10)
     """
-    w = np.sqrt(Ns*np.var(x)*10**(-EsN0/10.)/2.)*(np.random.randn(len(x)) + 1j*np.random.randn(len(x)))                            
+    w = np.sqrt(ns * np.var(x) * 10 ** (-es_n0 / 10.) / 2.) * (np.random.randn(len(x)) + 1j * np.random.randn(len(x)))
     return x+w       
 
 
@@ -2387,7 +2387,7 @@ def my_psd(x,NFFT=2**10,Fs=1):
     >>> import matplotlib.pyplot as plt
     >>> from numpy import log10
     >>> from sk_dsp_comm import sigsys as ss
-    >>> x,b, data = ss.NRZ_bits(10000,10)
+    >>> x,b, data = ss.nrz_bits(10000,10)
     >>> Px,f = ss.my_psd(x,2**10,10)
     >>> plt.plot(f, 10*log10(Px))
     >>> plt.ylabel("Power Spectral Density (dB)")
@@ -2483,7 +2483,7 @@ def am_rx(x192):
     return m_rx8,t8,m_rx192,x_edet192
 
 
-def am_rx_BPF(N_order = 7, ripple_dB = 1, B = 10e3, fs = 192e3):
+def am_rx_bpf(n_order=7, ripple_dB=1, b=10e3, fs=192e3):
     """
     Bandpass filter design for the AM receiver Case Study of Chapter 17.
 
@@ -2492,9 +2492,9 @@ def am_rx_BPF(N_order = 7, ripple_dB = 1, B = 10e3, fs = 192e3):
     
     Parameters
     ----------
-    N_order : the filter order (default = 7)
+    n_order : the filter order (default = 7)
     ripple_dB : the passband ripple in dB (default = 1)
-    B : the RF bandwidth (default = 10e3)
+    b : the RF bandwidth (default = 10e3)
     fs : the sampling frequency 
 
     Returns
@@ -2509,7 +2509,7 @@ def am_rx_BPF(N_order = 7, ripple_dB = 1, B = 10e3, fs = 192e3):
     >>> import matplotlib.pyplot as plt
     >>> import sk_dsp_comm.sigsys as ss
     >>> # Use the default values
-    >>> b_bpf,a_bpf = ss.am_rx_BPF()
+    >>> b_bpf,a_bpf = ss.am_rx_bpf()
 
     Pole-zero plot of the filter.
 
@@ -2526,7 +2526,7 @@ def am_rx_BPF(N_order = 7, ripple_dB = 1, B = 10e3, fs = 192e3):
     >>> plt.xlabel("Frequency (kHz)")
     >>> plt.show()
     """
-    b_bpf,a_bpf = signal.cheby1(N_order,ripple_dB,2*np.array([75e3-B/2.,75e3+B/2.])/fs,'bandpass')
+    b_bpf,a_bpf = signal.cheby1(n_order, ripple_dB, 2 * np.array([75e3 - b / 2., 75e3 + b / 2.]) / fs, 'bandpass')
     return b_bpf,a_bpf
     
     
@@ -2823,7 +2823,7 @@ def zplane(b,a,auto_scale=True,size=2,detect_mult=True,tol=0.001):
     return M,N
 
 
-def rect_conv(n,N_len):
+def rect_conv(n, n_len):
     """
     The theoretical result of convolving two rectangle sequences.
     
@@ -2834,7 +2834,7 @@ def rect_conv(n,N_len):
     Parameters
     ----------
     n : ndarray of time axis
-    N_len : rectangle pulse duration
+    n_len : rectangle pulse duration
     
     Returns
     -------
@@ -2852,10 +2852,10 @@ def rect_conv(n,N_len):
     """
     y = np.zeros(len(n))
     for k in range(len(n)):
-        if n[k] >= 0 and n[k] < N_len-1:
+        if n[k] >= 0 and n[k] < n_len-1:
             y[k] = n[k] + 1
-        elif n[k] >= N_len-1 and n[k] <= 2*N_len-2:
-            y[k] = 2*N_len-1-n[k]
+        elif n[k] >= n_len-1 and n[k] <= 2*n_len-2:
+            y[k] = 2 * n_len - 1 - n[k]
             
     return y
              
@@ -2884,7 +2884,8 @@ def biquad2(w_num, r_num, w_den, r_den):
     a = np.array([1, -2*r_den*np.cos(w_den), r_den**2])
     return b, a
 
-def plot_na(x,y,mode='stem'):
+
+def plot_na(x, y, mode='stem'):
     pylab.figure(figsize=(5,2))
     frame1 = pylab.gca()
     if mode.lower() == 'stem':
@@ -2921,7 +2922,7 @@ def from_wav(filename):
     return fs, x/32767.
 
 
-def to_wav(filename,rate,x):
+def to_wav(filename, rate, x):
     """
     Write a wave file.
 

--- a/sk_dsp_comm/synchronization.py
+++ b/sk_dsp_comm/synchronization.py
@@ -274,41 +274,41 @@ def DD_carrier_sync(z, M, BnTs, zeta=0.707, mod_type = 'MPSK', type = 0, open_lo
     return z_prime, a_hat, e_phi, theta_h
 
 
-def time_step(z,Ns,t_step,Nstep):
+def time_step(z, ns, t_step, n_step):
     """
     Create a one sample per symbol signal containing a phase rotation
     step Nsymb into the waveform.
 
     :param z: complex baseband signal after matched filter
-    :param Ns: number of sample per symbol
+    :param ns: number of sample per symbol
     :param t_step: in samples relative to Ns
-    :param Nstep: symbol sample location where the step turns on
+    :param n_step: symbol sample location where the step turns on
     :return: the one sample per symbol signal containing the phase step
 
     Mark Wickert July 2014
     """
-    z_step = np.hstack((z[:Ns*Nstep], z[(Ns*Nstep+t_step):], np.zeros(t_step)))
+    z_step = np.hstack((z[:ns * n_step], z[(ns * n_step + t_step):], np.zeros(t_step)))
     return z_step
 
 
-def phase_step(z,Ns,p_step,Nstep):
+def phase_step(z, ns, p_step, n_step):
     """
     Create a one sample per symbol signal containing a phase rotation
     step Nsymb into the waveform.
 
     :param z: complex baseband signal after matched filter
-    :param Ns: number of sample per symbol
+    :param ns: number of sample per symbol
     :param p_step: size in radians of the phase step
-    :param Nstep: symbol sample location where the step turns on
+    :param n_step: symbol sample location where the step turns on
     :return: the one sample symbol signal containing the phase step
 
     Mark Wickert July 2014
     """
-    nn = np.arange(0,len(z[::Ns]))
+    nn = np.arange(0, len(z[::ns]))
     theta = np.zeros(len(nn))
-    idx = np.where(nn >= Nstep)
+    idx = np.where(nn >= n_step)
     theta[idx] = p_step*np.ones(len(idx))
-    z_rot = z[::Ns]*np.exp(1j*theta)
+    z_rot = z[::ns] * np.exp(1j * theta)
     return z_rot
 
 

--- a/sk_dsp_comm/test/sandbox.py
+++ b/sk_dsp_comm/test/sandbox.py
@@ -5,7 +5,7 @@ from sk_dsp_comm import digitalcom as dc
 
 np.random.seed(100)
 
-cc = fec_conv.fec_conv()
+cc = fec_conv.FecConv()
 print(cc.Nstates)
 
 import matplotlib.pyplot as plt

--- a/sk_dsp_comm/test/test_coeff2header.py
+++ b/sk_dsp_comm/test/test_coeff2header.py
@@ -14,11 +14,11 @@ class TestCoeff2header(SKDSPCommTest):
 
     @classmethod
     def setUpClass(cls):
-        cls.tmpFiles = []
+        cls.tmp_files = []
 
     @classmethod
     def tearDownClass(cls):
-        for filename in cls.tmpFiles:
+        for filename in cls.tmp_files:
             try:
                 os.unlink(filename)
             except OSError as ose:
@@ -38,7 +38,7 @@ class TestCoeff2header(SKDSPCommTest):
         n = np.arange(0, 501)
         x = 3 * np.cos(2 * np.pi * f1 / fs * n) + 2 * np.sin(2 * np.pi * f2 / fs * n)
         test_fir = tempfile.NamedTemporaryFile()
-        self.tmpFiles.append(test_fir.name)
+        self.tmp_files.append(test_fir.name)
         c2head.fir_header(test_fir.name, x)
         test_fir_lines = test_fir.readlines()
         for line in range(0, len(f_header_check)):
@@ -52,7 +52,7 @@ class TestCoeff2header(SKDSPCommTest):
         ca_1 = open(dir_path + 'CA_1.h', 'r')
         ca_1 = ca_1.readlines()
         test_1 = tempfile.NamedTemporaryFile()
-        self.tmpFiles.append(test_1.name)
+        self.tmp_files.append(test_1.name)
         c2head.ca_code_header(test_1.name, 1)
         test_1_lines = test_1.readlines()
         for line in range(0, len(ca_1)):
@@ -66,7 +66,7 @@ class TestCoeff2header(SKDSPCommTest):
         ca_1 = open(dir_path + 'CA_12.h', 'r')
         ca_1 = ca_1.readlines()
         test_12 = tempfile.NamedTemporaryFile()
-        self.tmpFiles.append(test_12.name)
+        self.tmp_files.append(test_12.name)
         c2head.ca_code_header(test_12.name, 12)
         test_12_lines = test_12.readlines()
         for line in range(0, len(ca_1)):

--- a/sk_dsp_comm/test/test_coeff2header.py
+++ b/sk_dsp_comm/test/test_coeff2header.py
@@ -39,7 +39,7 @@ class TestCoeff2header(SKDSPCommTest):
         x = 3 * np.cos(2 * np.pi * f1 / fs * n) + 2 * np.sin(2 * np.pi * f2 / fs * n)
         test_fir = tempfile.NamedTemporaryFile()
         self.tmpFiles.append(test_fir.name)
-        c2head.FIR_header(test_fir.name, x)
+        c2head.fir_header(test_fir.name, x)
         test_fir_lines = test_fir.readlines()
         for line in range(0, len(f_header_check)):
             self.assertEqual(f_header_check[line], test_fir_lines[line].decode('UTF-8'))
@@ -53,7 +53,7 @@ class TestCoeff2header(SKDSPCommTest):
         ca_1 = ca_1.readlines()
         test_1 = tempfile.NamedTemporaryFile()
         self.tmpFiles.append(test_1.name)
-        c2head.CA_code_header(test_1.name, 1)
+        c2head.ca_code_header(test_1.name, 1)
         test_1_lines = test_1.readlines()
         for line in range(0, len(ca_1)):
             self.assertEqual(ca_1[line], test_1_lines[line].decode('UTF-8'))
@@ -67,7 +67,7 @@ class TestCoeff2header(SKDSPCommTest):
         ca_1 = ca_1.readlines()
         test_12 = tempfile.NamedTemporaryFile()
         self.tmpFiles.append(test_12.name)
-        c2head.CA_code_header(test_12.name, 12)
+        c2head.ca_code_header(test_12.name, 12)
         test_12_lines = test_12.readlines()
         for line in range(0, len(ca_1)):
             self.assertEqual(ca_1[line], test_12_lines[line].decode('UTF-8'))

--- a/sk_dsp_comm/test/test_digitalcom.py
+++ b/sk_dsp_comm/test/test_digitalcom.py
@@ -79,7 +79,7 @@ class TestDigitalcom(SKDSPCommTest):
         0.00102417, -0.00582846,  0.00376109,  0.00137866, -0.00293625]),
                                   np.array([-1.-1.j, -1.+1.j,  1.-1.j,  1.-1.j,  1.-1.j,  1.-1.j, -1.+1.j,
        -1.-1.j, -1.-1.j, -1.+1.j]))
-        x, b, t = dc.QAM_bb(10, 2, mod_type='qpsk', pulse='src')
+        x, b, t = dc.qam_bb(10, 2, mod='qpsk', pulse='src')
         npt.assert_almost_equal(x, x_test)
         npt.assert_almost_equal(b, b_test)
         npt.assert_almost_equal(t, t_test)
@@ -114,7 +114,7 @@ class TestDigitalcom(SKDSPCommTest):
         -9.23891131e-04,  -1.22314501e-18,   2.03243583e-03,
          1.11223990e-18]), np.array([-1.-1.j, -1.+1.j,  1.-1.j,  1.-1.j,  1.-1.j,  1.-1.j, -1.+1.j,
         -1.-1.j, -1.-1.j, -1.+1.j]))
-        x, b, t = dc.QAM_bb(10, 2, mod_type='qpsk', pulse='rc')
+        x, b, t = dc.qam_bb(10, 2, mod='qpsk', pulse='rc')
         npt.assert_almost_equal(x, x_test)
         npt.assert_almost_equal(b, b_test)
         npt.assert_almost_equal(t, t_test)
@@ -125,14 +125,14 @@ class TestDigitalcom(SKDSPCommTest):
        -1.-1.j, -1.-1.j, -1.-1.j, -1.-1.j, -1.+1.j, -1.+1.j]), np.array([ 0.5,  0.5]),
                                   np.array([-1.-1.j, -1.+1.j,  1.-1.j,  1.-1.j,  1.-1.j,  1.-1.j, -1.+1.j,
        -1.-1.j, -1.-1.j, -1.+1.j]))
-        x, b, t = dc.QAM_bb(10, 2, mod_type='qpsk', pulse='rect')
+        x, b, t = dc.qam_bb(10, 2, mod='qpsk', pulse='rect')
         npt.assert_almost_equal(x, x_test)
         npt.assert_almost_equal(b, b_test)
         npt.assert_almost_equal(t, t_test)
 
     def test_QAM_bb_pulse_error(self):
         with self.assertRaisesRegexp(ValueError, 'pulse shape must be src, rc, or rect'):
-            dc.QAM_bb(10, 2, pulse='value')
+            dc.qam_bb(10, 2, pulse='value')
 
     def test_QAM_bb_16qam_rect(self):
         x_test, b_test, t_test = (np.array([-1.00000000+0.33333333j, -1.00000000+0.33333333j,
@@ -147,7 +147,7 @@ class TestDigitalcom(SKDSPCommTest):
        -1.00000000+1.j        , -1.00000000+1.j        ]), np.array([ 0.5,  0.5]),
                                   np.array([-3.+1.j, -3.-1.j,  3.+1.j,  3.+1.j,  3.+1.j,  3.+1.j, -3.-1.j,
         1.-3.j,  1.-3.j, -3.+3.j]))
-        x, b, t = dc.QAM_bb(10, 2, mod_type='16qam', pulse='rect')
+        x, b, t = dc.qam_bb(10, 2, mod='16qam', pulse='rect')
         npt.assert_almost_equal(x, x_test)
         npt.assert_almost_equal(b, b_test)
         npt.assert_almost_equal(t, t_test)
@@ -165,7 +165,7 @@ class TestDigitalcom(SKDSPCommTest):
         0.14285714+1.j        ,  0.14285714+1.j        ]), np.array([ 0.5,  0.5]),
                                   np.array([-7.-3.j, -7.+3.j, -1.-3.j,  7.-3.j,  7.+5.j,  7.-3.j, -7.-5.j,
        -3.-7.j,  5.-7.j,  1.+7.j]))
-        x, b, t = dc.QAM_bb(10, 2, mod_type='64qam', pulse='rect')
+        x, b, t = dc.qam_bb(10, 2, mod='64qam', pulse='rect')
         npt.assert_almost_equal(x, x_test)
         npt.assert_almost_equal(b, b_test)
         npt.assert_almost_equal(t, t_test)
@@ -183,67 +183,67 @@ class TestDigitalcom(SKDSPCommTest):
        -0.46666667+1.j        , -0.46666667+1.j        ]), np.array([ 0.5,  0.5]),
                                   np.array([  1.-11.j,   1. -5.j,  -9.-11.j,  -1.-11.j,  -1.+13.j,  15.-11.j,
        -15.-13.j,   5.-15.j,  13. +1.j,  -7.+15.j]))
-        x, b, t = dc.QAM_bb(10, 2, mod_type='256qam', pulse='rect')
+        x, b, t = dc.qam_bb(10, 2, mod='256qam', pulse='rect')
         npt.assert_almost_equal(x, x_test)
         npt.assert_almost_equal(b, b_test)
         npt.assert_almost_equal(t, t_test)
 
     def test_QAM_bb_mod_error(self):
         with self.assertRaisesRegexp(ValueError, 'Unknown mod_type'):
-            x, b, t = dc.QAM_bb(10, 2, mod_type='unknown')
+            x, b, t = dc.qam_bb(10, 2, mod='unknown')
 
     def test_QAM_SEP_mod_error(self):
         tx = np.ones(10)
         rx = np.ones(10)
         with self.assertRaisesRegexp(ValueError, 'Unknown mod_type'):
-            dc.QAM_SEP(tx, rx, 'unknown')
+            dc.qam_sep(tx, rx, 'unknown')
 
     def test_QAM_SEP_16qam_no_error(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 0, 0.0)
-        x, b, tx_data = dc.QAM_bb(5000, 10, '16qam', 'src')
+        x, b, tx_data = dc.qam_bb(5000, 10, '16qam', 'src')
         x = dc.cpx_awgn(x, 20, 10)
         y = signal.lfilter(b, 1, x)
-        Nsymb, Nerr, SEP = dc.QAM_SEP(tx_data, y[10 + 10 * 12::10], '16qam', Ntransient=0)
+        Nsymb, Nerr, SEP = dc.qam_sep(tx_data, y[10 + 10 * 12::10], '16qam', n_transient=0)
         self.assertEqual(Nsymb, Nsymb_test)
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
     def test_QAM_SEP_16qam_error(self):
         Nsymb_test, Nerr_test, SEP_test = (9976, 172, 0.017241379310344827)
-        x, b, tx_data = dc.QAM_bb(10000, 1, '16qam', 'rect')
+        x, b, tx_data = dc.qam_bb(10000, 1, '16qam', 'rect')
         x = dc.cpx_awgn(x, 15, 1)
         y = signal.lfilter(b, 1, x)
-        Nsymb, Nerr, SEP = dc.QAM_SEP(tx_data, y[1 * 12::1], '16qam', Ntransient=0)
+        Nsymb, Nerr, SEP = dc.qam_sep(tx_data, y[1 * 12::1], '16qam', n_transient=0)
         self.assertEqual(Nsymb, Nsymb_test)
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
     def test_QAM_SEP_qpsk(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 0, 0.0)
-        x,b,tx_data = dc.QAM_bb(5000,10,'qpsk','src')
+        x,b,tx_data = dc.qam_bb(5000, 10, 'qpsk', 'src')
         x = dc.cpx_awgn(x, 20, 10)
         y = signal.lfilter(b,1,x)
-        Nsymb,Nerr,SEP = dc.QAM_SEP(tx_data,y[10+10*12::10],'qpsk',Ntransient=0)
+        Nsymb,Nerr,SEP = dc.qam_sep(tx_data, y[10 + 10 * 12::10], 'qpsk', n_transient=0)
         self.assertEqual(Nsymb, Nsymb_test)
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
     def test_QAM_SEP_64qam(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 245, 0.04913758523866827)
-        x, b, tx_data = dc.QAM_bb(5000, 10, '64qam', 'src')
+        x, b, tx_data = dc.qam_bb(5000, 10, '64qam', 'src')
         x = dc.cpx_awgn(x, 20, 10)
         y = signal.lfilter(b, 1, x)
-        Nsymb, Nerr, SEP = dc.QAM_SEP(tx_data, y[10 + 10 * 12::10], '64qam', Ntransient=0)
+        Nsymb, Nerr, SEP = dc.qam_sep(tx_data, y[10 + 10 * 12::10], '64qam', n_transient=0)
         self.assertEqual(Nsymb, Nsymb_test)
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
     def test_QAM_SEP_256qam(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 2190, 0.43922984356197353)
-        x, b, tx_data = dc.QAM_bb(5000, 10, '256qam', 'src')
+        x, b, tx_data = dc.qam_bb(5000, 10, '256qam', 'src')
         x = dc.cpx_awgn(x, 20, 10)
         y = signal.lfilter(b, 1, x)
-        Nsymb, Nerr, SEP = dc.QAM_SEP(tx_data, y[10 + 10 * 12::10], '256qam', Ntransient=0)
+        Nsymb, Nerr, SEP = dc.qam_sep(tx_data, y[10 + 10 * 12::10], '256qam', n_transient=0)
         self.assertEqual(Nsymb, Nsymb_test)
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
@@ -270,7 +270,7 @@ class TestDigitalcom(SKDSPCommTest):
         -7.07106781e-01 -7.07106781e-01j,
         -1.00000000e+00 -1.22464680e-16j]),
         np.array([0, 0, 1, 1, 1, 1, 0, 0, 0, 0]))
-        y, data = dc.GMSK_bb(10, 2)
+        y, data = dc.gmsk_bb(10, 2)
         npt.assert_almost_equal(y, y_test)
         npt.assert_equal(data, data_test)
 
@@ -278,7 +278,7 @@ class TestDigitalcom(SKDSPCommTest):
         x_test, b_test, data_test = (np.array([ 1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,
         1.+0.j,  1.+0.j,  1.+0.j]), np.array([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1,  0.1,  0.1,  0.1,  0.1]),
                                     np.array([0, 0, 3, 7, 7, 7, 0, 2, 6, 4]))
-        x, b, data = dc.MPSK_bb(500, 10, 8, 'rect', 0.35)
+        x, b, data = dc.mpsk_bb(500, 10, 8, 'rect', 0.35)
         npt.assert_equal(x[:10], x_test)
         npt.assert_almost_equal(b[:10], b_test)
         npt.assert_almost_equal(data[:10], data_test)
@@ -291,7 +291,7 @@ class TestDigitalcom(SKDSPCommTest):
          3.02766347e-04,   3.73320945e-04,   4.07129297e-04,
          3.96939751e-04,   3.41846688e-04,   2.48001733e-04,
          1.28158429e-04]), np.array([0, 0, 3, 7, 7, 7, 0, 2, 6, 4]))
-        x, b, data = dc.MPSK_bb(500, 10, 8, 'rc', 0.35)
+        x, b, data = dc.mpsk_bb(500, 10, 8, 'rc', 0.35)
         npt.assert_almost_equal(x[:10], x_test)
         npt.assert_almost_equal(b[:10], b_test)
         npt.assert_almost_equal(data[:10], data_test)
@@ -303,14 +303,14 @@ class TestDigitalcom(SKDSPCommTest):
         -3.37560604e-04,  -5.30419514e-05,   2.75015614e-04,
          5.91323287e-04,   8.38013686e-04,   9.64778341e-04,
          9.38445583e-04]), np.array([0, 0, 3, 7, 7, 7, 0, 2, 6, 4]))
-        x, b, data = dc.MPSK_bb(500, 10, 8, 'src', 0.35)
+        x, b, data = dc.mpsk_bb(500, 10, 8, 'src', 0.35)
         npt.assert_almost_equal(x[:10], x_test)
         npt.assert_almost_equal(b[:10], b_test)
         npt.assert_almost_equal(data[:10], data_test)
 
     def test_MPSK_bb_value_error(self):
         with self.assertRaisesRegexp(ValueError, "pulse type must be rec, rc, or src"):
-            x, b, data = dc.MPSK_bb(500, 10, 8, 'error')
+            x, b, data = dc.mpsk_bb(500, 10, 8, 'error')
 
     def test_ODFM_tx(self):
         x_out_test = np.array([ 0.00000000+0.125j,      -0.10185331+0.27369942j, -0.10291586+0.12529202j,
@@ -330,8 +330,8 @@ class TestDigitalcom(SKDSPCommTest):
                                 0.00806130-0.17969398j, -0.00105255+0.03378639j,  0.15279016+0.16494501j,
                                 0.09844557-0.009236j,   -0.11589986-0.20597693j, -0.10438721-0.09983656j,
                                 0.15625000+0.09375j,     0.22805837+0.03951473j,])
-        x1, b1, IQ_data1 = dc.QAM_bb(50000, 1, '16qam')
-        x_out = dc.OFDM_tx(IQ_data1, 32, 64, 0, True, 0)
+        x1, b1, IQ_data1 = dc.qam_bb(50000, 1, '16qam')
+        x_out = dc.ofdm_tx(IQ_data1, 32, 64, 0, True, 0)
         npt.assert_almost_equal(x_out[:50], x_out_test)
 
     def test_OFDM_rx(self):
@@ -362,11 +362,11 @@ class TestDigitalcom(SKDSPCommTest):
                                         1.09530096 + 3.87688911e-01j, 1.23071709 + 3.51736667e-01j,
                                         1.34580486 + 2.66705232e-01j, 1.42289223 + 1.43696423e-01j]))
         hc = np.array([1.0, 0.1, -0.05, 0.15, 0.2, 0.05])
-        x1, b1, IQ_data1 = dc.QAM_bb(50000, 1, '16qam')
-        x_out = dc.OFDM_tx(IQ_data1, 32, 64, 0, True, 0)
+        x1, b1, IQ_data1 = dc.qam_bb(50000, 1, '16qam')
+        x_out = dc.ofdm_tx(IQ_data1, 32, 64, 0, True, 0)
         c_out = signal.lfilter(hc, 1, x_out)  # Apply channel distortion
         r_out = dc.cpx_awgn(c_out, 100, 64 / 32)  # Es/N0 = 100 dB
-        z_out, H = dc.OFDM_rx(r_out, 32, 64, -1, True, 0, alpha=0.95, ht=hc);
+        z_out, H = dc.ofdm_rx(r_out, 32, 64, -1, True, 0, alpha=0.95, ht=hc);
         npt.assert_almost_equal(z_out[:20], z_out_test)
         npt.assert_almost_equal(H, H_test)
 
@@ -413,10 +413,10 @@ class TestDigitalcom(SKDSPCommTest):
                                              0.98676887+0.4108844j ,  1.26869289+0.35672436j,
                                              1.44594176+0.3296819j ,  1.48817425+0.07577518j]))
         hc = np.array([1.0, 0.1, -0.05, 0.15, 0.2, 0.05])
-        x1, b1, IQ_data1 = dc.QAM_bb(50000, 1, '16qam')
-        x_out = dc.OFDM_tx(IQ_data1, 32, 64, 100, True, 10)
+        x1, b1, IQ_data1 = dc.qam_bb(50000, 1, '16qam')
+        x_out = dc.ofdm_tx(IQ_data1, 32, 64, 100, True, 10)
         c_out = signal.lfilter(hc, 1, x_out)  # Apply channel distortion
         r_out = dc.cpx_awgn(c_out, 25, 64 / 32)  # Es/N0 = 25 dB
-        z_out, H = dc.OFDM_rx(r_out, 32, 64, 100, True, 10, alpha=0.95, ht=hc)
+        z_out, H = dc.ofdm_rx(r_out, 32, 64, 100, True, 10, alpha=0.95, ht=hc)
         npt.assert_almost_equal(z_out[:50], z_out_test)
         npt.assert_almost_equal(H[:50], H_out_test)

--- a/sk_dsp_comm/test/test_digitalcom.py
+++ b/sk_dsp_comm/test/test_digitalcom.py
@@ -249,7 +249,7 @@ class TestDigitalcom(SKDSPCommTest):
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
-    def test_GMSK_bb(self):
+    def test_gmsk_bb(self):
         y_test, data_test = (np.array([  7.07106781e-01 -7.07106781e-01j,
         6.12323400e-17 -1.00000000e+00j,
         -7.07106781e-01 -7.07106781e-01j,
@@ -275,7 +275,7 @@ class TestDigitalcom(SKDSPCommTest):
         npt.assert_almost_equal(y, y_test)
         npt.assert_equal(data, data_test)
 
-    def test_MPSK_bb_rect(self):
+    def test_mpsk_bb_rect(self):
         x_test, b_test, data_test = (np.array([ 1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,  1.+0.j,
         1.+0.j,  1.+0.j,  1.+0.j]), np.array([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1,  0.1,  0.1,  0.1,  0.1]),
                                     np.array([0, 0, 3, 7, 7, 7, 0, 2, 6, 4]))
@@ -284,7 +284,7 @@ class TestDigitalcom(SKDSPCommTest):
         npt.assert_almost_equal(b[:10], b_test)
         npt.assert_almost_equal(data[:10], data_test)
 
-    def test_MPSK_bb_rc(self):
+    def test_mpsk_bb_rc(self):
         x_test, b_test, data_test = (np.array([  2.22799382e-18+0.j,   1.01671750e-03+0.j,   2.07413572e-03+0.j,
          3.02766347e-03+0.j,   3.73320945e-03+0.j,   4.07129297e-03+0.j,
          3.96939751e-03+0.j,   3.41846688e-03+0.j,   2.48001733e-03+0.j,
@@ -297,7 +297,7 @@ class TestDigitalcom(SKDSPCommTest):
         npt.assert_almost_equal(b[:10], b_test)
         npt.assert_almost_equal(data[:10], data_test)
 
-    def test_MPSK_bb_src(self):
+    def test_mpsk_bb_src(self):
         x_test, b_test, data_test = (np.array([-0.00585723+0.j, -0.00619109+0.j, -0.00534820+0.j, -0.00337561+0.j,
        -0.00053042+0.j,  0.00275016+0.j,  0.00591323+0.j,  0.00838014+0.j,
         0.00964778+0.j,  0.00938446+0.j]), np.array([ -5.85723271e-04,  -6.19109164e-04,  -5.34820232e-04,
@@ -309,7 +309,7 @@ class TestDigitalcom(SKDSPCommTest):
         npt.assert_almost_equal(b[:10], b_test)
         npt.assert_almost_equal(data[:10], data_test)
 
-    def test_MPSK_bb_value_error(self):
+    def test_mpsk_bb_value_error(self):
         with self.assertRaisesRegexp(ValueError, "pulse type must be rec, rc, or src"):
             x, b, data = dc.mpsk_bb(500, 10, 8, 'error')
 

--- a/sk_dsp_comm/test/test_digitalcom.py
+++ b/sk_dsp_comm/test/test_digitalcom.py
@@ -49,7 +49,7 @@ class TestDigitalcom(SKDSPCommTest):
          4.44335938e-02,   2.52075195e-02,   1.23901367e-02,
          5.12695312e-03,   1.70898438e-03,   4.27246094e-04,
          6.10351562e-05])
-        b = dc.CIC(4, 7)
+        b = dc.cic(4, 7)
         npt.assert_almost_equal(b_test, b)
 
     def test_CIC_1(self):
@@ -58,7 +58,7 @@ class TestDigitalcom(SKDSPCommTest):
         :return:
         """
         b_test = np.ones(4) / 4
-        b = dc.CIC(4, 1)
+        b = dc.cic(4, 1)
         npt.assert_almost_equal(b_test, b)
 
     def test_QAM_bb_qpsk_src(self):

--- a/sk_dsp_comm/test/test_digitalcom.py
+++ b/sk_dsp_comm/test/test_digitalcom.py
@@ -201,7 +201,7 @@ class TestDigitalcom(SKDSPCommTest):
     def test_QAM_SEP_16qam_no_error(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 0, 0.0)
         x, b, tx_data = dc.QAM_bb(5000, 10, '16qam', 'src')
-        x = dc.cpx_AWGN(x, 20, 10)
+        x = dc.cpx_awgn(x, 20, 10)
         y = signal.lfilter(b, 1, x)
         Nsymb, Nerr, SEP = dc.QAM_SEP(tx_data, y[10 + 10 * 12::10], '16qam', Ntransient=0)
         self.assertEqual(Nsymb, Nsymb_test)
@@ -211,7 +211,7 @@ class TestDigitalcom(SKDSPCommTest):
     def test_QAM_SEP_16qam_error(self):
         Nsymb_test, Nerr_test, SEP_test = (9976, 172, 0.017241379310344827)
         x, b, tx_data = dc.QAM_bb(10000, 1, '16qam', 'rect')
-        x = dc.cpx_AWGN(x, 15, 1)
+        x = dc.cpx_awgn(x, 15, 1)
         y = signal.lfilter(b, 1, x)
         Nsymb, Nerr, SEP = dc.QAM_SEP(tx_data, y[1 * 12::1], '16qam', Ntransient=0)
         self.assertEqual(Nsymb, Nsymb_test)
@@ -221,7 +221,7 @@ class TestDigitalcom(SKDSPCommTest):
     def test_QAM_SEP_qpsk(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 0, 0.0)
         x,b,tx_data = dc.QAM_bb(5000,10,'qpsk','src')
-        x = dc.cpx_AWGN(x,20,10)
+        x = dc.cpx_awgn(x, 20, 10)
         y = signal.lfilter(b,1,x)
         Nsymb,Nerr,SEP = dc.QAM_SEP(tx_data,y[10+10*12::10],'qpsk',Ntransient=0)
         self.assertEqual(Nsymb, Nsymb_test)
@@ -231,7 +231,7 @@ class TestDigitalcom(SKDSPCommTest):
     def test_QAM_SEP_64qam(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 245, 0.04913758523866827)
         x, b, tx_data = dc.QAM_bb(5000, 10, '64qam', 'src')
-        x = dc.cpx_AWGN(x, 20, 10)
+        x = dc.cpx_awgn(x, 20, 10)
         y = signal.lfilter(b, 1, x)
         Nsymb, Nerr, SEP = dc.QAM_SEP(tx_data, y[10 + 10 * 12::10], '64qam', Ntransient=0)
         self.assertEqual(Nsymb, Nsymb_test)
@@ -241,7 +241,7 @@ class TestDigitalcom(SKDSPCommTest):
     def test_QAM_SEP_256qam(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 2190, 0.43922984356197353)
         x, b, tx_data = dc.QAM_bb(5000, 10, '256qam', 'src')
-        x = dc.cpx_AWGN(x, 20, 10)
+        x = dc.cpx_awgn(x, 20, 10)
         y = signal.lfilter(b, 1, x)
         Nsymb, Nerr, SEP = dc.QAM_SEP(tx_data, y[10 + 10 * 12::10], '256qam', Ntransient=0)
         self.assertEqual(Nsymb, Nsymb_test)
@@ -365,7 +365,7 @@ class TestDigitalcom(SKDSPCommTest):
         x1, b1, IQ_data1 = dc.QAM_bb(50000, 1, '16qam')
         x_out = dc.OFDM_tx(IQ_data1, 32, 64, 0, True, 0)
         c_out = signal.lfilter(hc, 1, x_out)  # Apply channel distortion
-        r_out = dc.cpx_AWGN(c_out, 100, 64 / 32)  # Es/N0 = 100 dB
+        r_out = dc.cpx_awgn(c_out, 100, 64 / 32)  # Es/N0 = 100 dB
         z_out, H = dc.OFDM_rx(r_out, 32, 64, -1, True, 0, alpha=0.95, ht=hc);
         npt.assert_almost_equal(z_out[:20], z_out_test)
         npt.assert_almost_equal(H, H_test)
@@ -416,7 +416,7 @@ class TestDigitalcom(SKDSPCommTest):
         x1, b1, IQ_data1 = dc.QAM_bb(50000, 1, '16qam')
         x_out = dc.OFDM_tx(IQ_data1, 32, 64, 100, True, 10)
         c_out = signal.lfilter(hc, 1, x_out)  # Apply channel distortion
-        r_out = dc.cpx_AWGN(c_out, 25, 64 / 32)  # Es/N0 = 25 dB
+        r_out = dc.cpx_awgn(c_out, 25, 64 / 32)  # Es/N0 = 25 dB
         z_out, H = dc.OFDM_rx(r_out, 32, 64, 100, True, 10, alpha=0.95, ht=hc)
         npt.assert_almost_equal(z_out[:50], z_out_test)
         npt.assert_almost_equal(H[:50], H_out_test)

--- a/sk_dsp_comm/test/test_digitalcom.py
+++ b/sk_dsp_comm/test/test_digitalcom.py
@@ -193,13 +193,13 @@ class TestDigitalcom(SKDSPCommTest):
         with self.assertRaisesRegexp(ValueError, 'Unknown mod_type'):
             x, b, t = dc.qam_bb(10, 2, mod='unknown')
 
-    def test_QAM_SEP_mod_error(self):
+    def test_qam_sep_mod_error(self):
         tx = np.ones(10)
         rx = np.ones(10)
         with self.assertRaisesRegexp(ValueError, 'Unknown mod_type'):
             dc.qam_sep(tx, rx, 'unknown')
 
-    def test_QAM_SEP_16qam_no_error(self):
+    def test_qam_sep_16qam_no_error(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 0, 0.0)
         x, b, tx_data = dc.qam_bb(5000, 10, '16qam', 'src')
         x = dc.cpx_awgn(x, 20, 10)
@@ -209,7 +209,7 @@ class TestDigitalcom(SKDSPCommTest):
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
-    def test_QAM_SEP_16qam_error(self):
+    def test_qam_sep_16qam_error(self):
         Nsymb_test, Nerr_test, SEP_test = (9976, 172, 0.017241379310344827)
         x, b, tx_data = dc.qam_bb(10000, 1, '16qam', 'rect')
         x = dc.cpx_awgn(x, 15, 1)
@@ -219,7 +219,7 @@ class TestDigitalcom(SKDSPCommTest):
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
-    def test_QAM_SEP_qpsk(self):
+    def test_qam_sep_qpsk(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 0, 0.0)
         x,b,tx_data = dc.qam_bb(5000, 10, 'qpsk', 'src')
         x = dc.cpx_awgn(x, 20, 10)
@@ -229,7 +229,7 @@ class TestDigitalcom(SKDSPCommTest):
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
-    def test_QAM_SEP_64qam(self):
+    def test_qam_sep_64qam(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 245, 0.04913758523866827)
         x, b, tx_data = dc.qam_bb(5000, 10, '64qam', 'src')
         x = dc.cpx_awgn(x, 20, 10)
@@ -239,7 +239,7 @@ class TestDigitalcom(SKDSPCommTest):
         self.assertEqual(Nerr, Nerr_test)
         self.assertEqual(SEP, SEP_test)
 
-    def test_QAM_SEP_256qam(self):
+    def test_qam_sep_256qam(self):
         Nsymb_test, Nerr_test, SEP_test = (4986, 2190, 0.43922984356197353)
         x, b, tx_data = dc.qam_bb(5000, 10, '256qam', 'src')
         x = dc.cpx_awgn(x, 20, 10)

--- a/sk_dsp_comm/test/test_fec_conv.py
+++ b/sk_dsp_comm/test/test_fec_conv.py
@@ -6,14 +6,14 @@ from numpy import testing as npt
 from sk_dsp_comm import digitalcom as dc
 
 
-class TestFecConv_1_2(SKDSPCommTest):
+class TestFecConv12(SKDSPCommTest):
     _multiprocess_can_split_ = True
 
     def test_fec_conv_inst(self):
-        cc1 = fec_conv.fec_conv(('101', '111'), Depth=10)  # decision depth is 10
+        cc1 = fec_conv.FecConv(('101', '111'), Depth=10)  # decision depth is 10
 
     def test_fec_conv_conv_encoder(self):
-        cc1 = fec_conv.fec_conv()
+        cc1 = fec_conv.FecConv()
         x = np.random.randint(0, 2, 20)
         state = '00'
         y_test, state_test = (np.array([ 0.,  0.,  0.,  0.,  1.,  1.,  0.,  1.,  1.,  0.,  1.,  0.,  0.,
@@ -24,7 +24,7 @@ class TestFecConv_1_2(SKDSPCommTest):
         self.assertEqual(state_test, state)
 
     def test_fec_conv_viterbi_decoder(self):
-        cc1 = fec_conv.fec_conv()
+        cc1 = fec_conv.FecConv()
         x = np.random.randint(0,2,20)
         state = '00'
         y, state = cc1.conv_encoder(x, state)
@@ -37,7 +37,7 @@ class TestFecConv_1_2(SKDSPCommTest):
     def test_fec_conv_puncture(self):
         yp_test = [0., 0.,  0.,  1.,  0.,  1.,  1.,  0.,  0.,  1.,  1.,  0.,  0.,  0.,  0.,  1.,  1.,  0.,
                    1.,  0.,  0.,  0.,  1.,  0.]
-        cc1 = fec_conv.fec_conv()
+        cc1 = fec_conv.FecConv()
         x = np.random.randint(0, 2, 20)
         state = '00'
         y, state = cc1.conv_encoder(x, state)
@@ -51,7 +51,7 @@ class TestFecConv_1_2(SKDSPCommTest):
                      1.54447404,  1.47065852, -0.24028734,  3.5,         3.5,         6.19633424,
                      7.1760269,   0.89395647,  7.69735877,  3.5,         3.5,         1.29889556,
                      -0.31122416,  0.05311373,  7.21216449,  3.5,         3.5,        -1.37679829]
-        cc1 = fec_conv.fec_conv()
+        cc1 = fec_conv.FecConv()
 
         x = np.random.randint(0, 2, 20)
         state = '00'
@@ -64,7 +64,7 @@ class TestFecConv_1_2(SKDSPCommTest):
 
     def test_fec_conv_Nstates(self):
         G = ('111', '101')
-        cc = fec_conv.fec_conv(G)
+        cc = fec_conv.FecConv(G)
         self.assertEqual(4, cc.Nstates)
 
     def test_fec_conv_conv_Pb_bound_2(self):

--- a/sk_dsp_comm/test/test_fec_conv.py
+++ b/sk_dsp_comm/test/test_fec_conv.py
@@ -10,10 +10,10 @@ class TestFecConv12(SKDSPCommTest):
     _multiprocess_can_split_ = True
 
     def test_fec_conv_inst(self):
-        cc1 = fec_conv.FecConv(('101', '111'), Depth=10)  # decision depth is 10
+        cc1 = fec_conv.FECConv(('101', '111'), Depth=10)  # decision depth is 10
 
     def test_fec_conv_conv_encoder(self):
-        cc1 = fec_conv.FecConv()
+        cc1 = fec_conv.FECConv()
         x = np.random.randint(0, 2, 20)
         state = '00'
         y_test, state_test = (np.array([ 0.,  0.,  0.,  0.,  1.,  1.,  0.,  1.,  1.,  0.,  1.,  0.,  0.,
@@ -24,7 +24,7 @@ class TestFecConv12(SKDSPCommTest):
         self.assertEqual(state_test, state)
 
     def test_fec_conv_viterbi_decoder(self):
-        cc1 = fec_conv.FecConv()
+        cc1 = fec_conv.FECConv()
         x = np.random.randint(0,2,20)
         state = '00'
         y, state = cc1.conv_encoder(x, state)
@@ -37,7 +37,7 @@ class TestFecConv12(SKDSPCommTest):
     def test_fec_conv_puncture(self):
         yp_test = [0., 0.,  0.,  1.,  0.,  1.,  1.,  0.,  0.,  1.,  1.,  0.,  0.,  0.,  0.,  1.,  1.,  0.,
                    1.,  0.,  0.,  0.,  1.,  0.]
-        cc1 = fec_conv.FecConv()
+        cc1 = fec_conv.FECConv()
         x = np.random.randint(0, 2, 20)
         state = '00'
         y, state = cc1.conv_encoder(x, state)
@@ -51,7 +51,7 @@ class TestFecConv12(SKDSPCommTest):
                      1.54447404,  1.47065852, -0.24028734,  3.5,         3.5,         6.19633424,
                      7.1760269,   0.89395647,  7.69735877,  3.5,         3.5,         1.29889556,
                      -0.31122416,  0.05311373,  7.21216449,  3.5,         3.5,        -1.37679829]
-        cc1 = fec_conv.FecConv()
+        cc1 = fec_conv.FECConv()
 
         x = np.random.randint(0, 2, 20)
         state = '00'
@@ -64,7 +64,7 @@ class TestFecConv12(SKDSPCommTest):
 
     def test_fec_conv_Nstates(self):
         G = ('111', '101')
-        cc = fec_conv.FecConv(G)
+        cc = fec_conv.FECConv(G)
         self.assertEqual(4, cc.Nstates)
 
     def test_fec_conv_conv_Pb_bound_2(self):

--- a/sk_dsp_comm/test/test_fec_conv.py
+++ b/sk_dsp_comm/test/test_fec_conv.py
@@ -29,7 +29,7 @@ class TestFecConv12(SKDSPCommTest):
         state = '00'
         y, state = cc1.conv_encoder(x, state)
         z_test = [ 0.,  0.,  1.,  1.,  1.,  1.,  0.,  0.,  0.,  0.,  0.]
-        yn = dc.cpx_AWGN(2 * y - 1, 5, 1)
+        yn = dc.cpx_awgn(2 * y - 1, 5, 1)
         yn = (yn.real + 1) / 2 * 7
         z = cc1.viterbi_decoder(yn)
         npt.assert_almost_equal(z_test, z)
@@ -57,7 +57,7 @@ class TestFecConv12(SKDSPCommTest):
         state = '00'
         y, state = cc1.conv_encoder(x, state)
         yp = cc1.puncture(y, ('110', '101'))
-        ypn = dc.cpx_AWGN(2 * yp - 1, 8, 1)
+        ypn = dc.cpx_awgn(2 * yp - 1, 8, 1)
         ypn = (ypn.real + 1) / 2 * 7
         zdpn = cc1.depuncture(ypn, ('110', '101'), 3.5)  # set erase threshold to 7/2
         npt.assert_almost_equal(zdpn_test, zdpn)

--- a/sk_dsp_comm/test/test_sigsys.py
+++ b/sk_dsp_comm/test/test_sigsys.py
@@ -685,6 +685,16 @@ class TestSigsys(SKDSPCommTest):
         with self.assertRaisesRegexp(ValueError, 'shape must be tri or line')as lp_s_err:
             ss.lp_samp(10, 25, 50, 10, shape='square')
 
+    def test_os_filter_0(self):
+        y_test = [1.,          1.95105652,  2.76007351,  3.34785876,  3.65687576,  3.65687576, 3.34785876,  2.76007351,
+                  1.95105652,  1.,         -1.,         -2.90211303,  -4.52014702, -5.69571753, -6.31375151,
+                  -6.31375151, -5.69571753, -4.52014702, -2.90211303, -1.]
+        n = np.arange(0, 20)
+        x = np.cos(2 * np.pi * 0.05 * n)
+        b = np.ones(10)
+        y = ss.os_filter(x, b, 2 ** 10)
+        npt.assert_almost_equal(y, y_test)
+
     def test_simple_quant_12_sat(self):
         n = np.arange(0, 10)
         x = np.cos(2 * np.pi * 0.211 * n)

--- a/sk_dsp_comm/test/test_sigsys.py
+++ b/sk_dsp_comm/test/test_sigsys.py
@@ -695,6 +695,16 @@ class TestSigsys(SKDSPCommTest):
         y = ss.os_filter(x, b, 2 ** 10)
         npt.assert_almost_equal(y, y_test)
 
+    def test_oa_filter_0(self):
+        y_test = [1.,          1.95105652,  2.76007351,  3.34785876,  3.65687576, 3.65687576, 3.34785876,  2.76007351,
+                  1.95105652,  1.,         -1.,         -2.90211303, -4.52014702, -5.69571753, -6.31375151, -6.31375151,
+                  -5.69571753, -4.52014702, -2.90211303, -1.]
+        n = np.arange(0, 20)
+        x = np.cos(2 * np.pi * 0.05 * n)
+        b = np.ones(10)
+        y = ss.oa_filter(x, b, 2 ** 10)
+        npt.assert_almost_equal(y, y_test)
+
     def test_simple_quant_12_sat(self):
         n = np.arange(0, 10)
         x = np.cos(2 * np.pi * 0.211 * n)

--- a/sk_dsp_comm/test/test_sigsys.py
+++ b/sk_dsp_comm/test/test_sigsys.py
@@ -685,7 +685,7 @@ class TestSigsys(SKDSPCommTest):
         with self.assertRaisesRegexp(ValueError, 'shape must be tri or line')as lp_s_err:
             ss.lp_samp(10, 25, 50, 10, shape='square')
 
-    def test_simpleQuant_12_sat(self):
+    def test_simple_quant_12_sat(self):
         n = np.arange(0, 10)
         x = np.cos(2 * np.pi * 0.211 * n)
         test_q = [0.99951172, 0.24267578, -0.88232422, -0.67089844, 0.55664062, 0.94091797, -0.10058594, -0.98974609,
@@ -693,7 +693,7 @@ class TestSigsys(SKDSPCommTest):
         q = ss.simple_quant(x, 12, 1, 'sat')
         npt.assert_almost_equal(q, test_q)
 
-    def test_simpleQuant_value_err(self):
+    def test_simple_quant_value_err(self):
         with self.assertRaisesRegexp(ValueError, "limit must be the string over, sat, or none") as sQ_err:
             ss.simple_quant(np.ones(12), 12, 12, 'under')
 

--- a/sk_dsp_comm/test/test_sigsys.py
+++ b/sk_dsp_comm/test/test_sigsys.py
@@ -12,7 +12,7 @@ class TestSigsys(SKDSPCommTest):
 
     def test_cic_case_1(self):
         correct = np.ones(10) / 10
-        b = ss.CIC(10, 1)
+        b = ss.cic(10, 1)
         diff = correct - b
         diff = np.sum(diff)
         self.assertEqual(diff, 0)
@@ -20,7 +20,7 @@ class TestSigsys(SKDSPCommTest):
     def test_cic_case_2(self):
         correct = [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1,
                    0.09, 0.08, 0.07, 0.06, 0.05, 0.04, 0.03, 0.02, 0.01]
-        b = ss.CIC(10, 2)
+        b = ss.cic(10, 2)
         diff = correct - b
         diff = np.sum(diff)
         self.assertEqual(diff, 0)
@@ -55,35 +55,35 @@ class TestSigsys(SKDSPCommTest):
         diff = np.sum(diff)
         self.assertEqual(diff, 0)
 
-    def test_position_CD_fb_approx(self):
+    def test_position_cd_fb_approx(self):
         Ka = 50
-        b, a = ss.position_CD(Ka, 'fb_approx')
+        b, a = ss.position_cd(Ka, 'fb_approx')
         b_check = np.array([254.64790895])
         a_check = np.array([1., 25., 254.64790895])
         npt.assert_almost_equal(b, b_check)
         npt.assert_almost_equal(a, a_check)
 
-    def test_position_CD_fb_exact(self):
+    def test_position_cd_fb_exact(self):
         Ka = 50
-        b, a = ss.position_CD(Ka, 'fb_exact')
+        b, a = ss.position_cd(Ka, 'fb_exact')
         b_check = np.array([318309.88618379])
         a_check = np.array([1.00000000e+00, 1.27500000e+03, 3.12500000e+04,
                             3.18309886e+05])
         npt.assert_almost_equal(b, b_check)
         npt.assert_almost_equal(a, a_check, decimal=3)
 
-    def test_position_CD_open_loop(self):
+    def test_position_cd_open_loop(self):
         Ka = 50
-        b, a = ss.position_CD(Ka, 'open_loop')
+        b, a = ss.position_cd(Ka, 'open_loop')
         b_check = np.array([318309.88618379])
         a_check = np.array([1, 1275, 31250, 0])
         npt.assert_almost_equal(b, b_check)
         npt.assert_almost_equal(a, a_check)
 
-    def test_position_CD_out_type_value_error(self):
+    def test_position_cd_out_type_value_error(self):
         Ka = 50
         with self.assertRaisesRegexp(ValueError, 'out_type must be: open_loop, fb_approx, or fc_exact') as cd_err:
-            b, a = ss.position_CD(Ka, 'value_error')
+            b, a = ss.position_cd(Ka, 'value_error')
 
     def test_cruise_control_H(self):
         wn = 0.1

--- a/sk_dsp_comm/test/test_sigsys.py
+++ b/sk_dsp_comm/test/test_sigsys.py
@@ -393,7 +393,7 @@ class TestSigsys(SKDSPCommTest):
         npt.assert_almost_equal(b, b_check)
 
     def test_PN_gen(self):
-        PN = ss.PN_gen(50, 4)
+        PN = ss.pn_gen(50, 4)
         PN_check = np.array([ 1.,  1.,  1.,  1.,  0.,  1.,  0.,  1.,  1.,  0.,  0.,  1.,  0.,
         0.,  0.,  1.,  1.,  1.,  1.,  0.,  1.,  0.,  1.,  1.,  0.,  0.,
         1.,  0.,  0.,  0.,  1.,  1.,  1.,  1.,  0.,  1.,  0.,  1.,  1.,
@@ -543,7 +543,7 @@ class TestSigsys(SKDSPCommTest):
             ss.m_seq(-1)
 
     def test_BPSK_tx(self):
-        x,b,data0 = ss.BPSK_tx(1000, 10,pulse='src')
+        x,b,data0 = ss.bpsk_tx(1000, 10, pulse='src')
         bit_vals = [0, 1]
         for bit in data0:
             val_check = bit in bit_vals
@@ -551,10 +551,10 @@ class TestSigsys(SKDSPCommTest):
 
     def test_BPSK_tx_value_error(self):
         with self.assertRaisesRegexp(ValueError, 'Pulse shape must be \'rect\' or \'src\'''') as bpsk_err:
-            ss.BPSK_tx(1000, 10, pulse='rc')
+            ss.bpsk_tx(1000, 10, pulse='rc')
 
     def test_NRZ_bits(self):
-        x, b, data = ss.NRZ_bits(25, 8)
+        x, b, data = ss.nrz_bits(25, 8)
         b_check = np.array([ 0.125,  0.125,  0.125,  0.125,  0.125,  0.125,  0.125,  0.125])
         x_vals = [-1, 1]
         data_vals = [0, 1]
@@ -568,14 +568,14 @@ class TestSigsys(SKDSPCommTest):
 
     def test_NRZ_bits_3(self):
         Tspan = 10  # Time span in seconds
-        PN, b, data = ss.NRZ_bits(1000 * Tspan, 8000 / 1000)
+        PN, b, data = ss.nrz_bits(1000 * Tspan, 8000 / 1000)
 
     def test_NRZ_bits_value_error(self):
         with self.assertRaisesRegexp(ValueError, 'pulse type must be rec, rc, or src') as NRZ_err:
-            x,b,data = ss.NRZ_bits(100, 10, pulse='value')
+            x,b,data = ss.nrz_bits(100, 10, pulse='value')
 
     def test_NRZ_bits2(self):
-        x,b = ss.NRZ_bits2(ss.m_seq(3), 10)
+        x,b = ss.nrz_bits2(ss.m_seq(3), 10)
         x_check = np.array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,
         1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,
         1.,  1.,  1.,  1., -1., -1., -1., -1., -1., -1., -1., -1., -1.,
@@ -591,11 +591,11 @@ class TestSigsys(SKDSPCommTest):
 
     def test_NRZ_bits2_value_error(self):
         with self.assertRaisesRegexp(ValueError, 'pulse type must be rec, rc, or src') as NRZ_err:
-            x,b = ss.NRZ_bits2(ss.m_seq(5), 10, pulse='val')
+            x,b = ss.nrz_bits2(ss.m_seq(5), 10, pulse='val')
 
     def test_bit_errors(self):
-        x, b, data = ss.NRZ_bits(1000000, 10)
-        y = ss.cpx_AWGN(x, 12, 10)
+        x, b, data = ss.nrz_bits(1000000, 10)
+        y = ss.cpx_awgn(x, 12, 10)
         z = signal.lfilter(b, 1, y)
         Pe_hat = ss.bit_errors(z, data, 10, 10)
         npt.assert_almost_equal(Pe_hat, 3.0000030000030001e-06, decimal=5)
@@ -690,12 +690,12 @@ class TestSigsys(SKDSPCommTest):
         x = np.cos(2 * np.pi * 0.211 * n)
         test_q = [0.99951172, 0.24267578, -0.88232422, -0.67089844, 0.55664062, 0.94091797, -0.10058594, -0.98974609,
                   -0.37988281, 0.80517578]
-        q = ss.simpleQuant(x, 12, 1, 'sat')
+        q = ss.simple_quant(x, 12, 1, 'sat')
         npt.assert_almost_equal(q, test_q)
 
     def test_simpleQuant_value_err(self):
         with self.assertRaisesRegexp(ValueError, "limit must be the string over, sat, or none") as sQ_err:
-            ss.simpleQuant(np.ones(12), 12, 12, 'under')
+            ss.simple_quant(np.ones(12), 12, 12, 'under')
 
     def test_ft_approx(self):
         f_check = [-0.9765625,  -0.95214844, -0.92773438, -0.90332031, -0.87890625, -0.85449219,


### PR DESCRIPTION
This will complete #42 .

Verified via test, but will require a refactoring of the notebooks. All methods use lower case with the exception of `dB` in the method name to avoid confusion. Any parameters related to a modulation schema are now `mod` and any optional usages of `m` or `mm` are related to pulse shaping and related usages.