### PR TITLE
Scipy version lock to < 1.14 for remez function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.20.0
 matplotlib>=3.0.0
-scipy>=1.1.0
+scipy>=1.1.0,<1.14


### PR DESCRIPTION
As noted [here in 1.13.1 docs](https://docs.scipy.org/doc/scipy-1.13.1/reference/generated/scipy.signal.remez.html), remez moved from using `Hz` to `fs` in 1.0.0.